### PR TITLE
Implement Rocket.Chat to Teams outbound messaging

### DIFF
--- a/TeamsBridgeApp.ts
+++ b/TeamsBridgeApp.ts
@@ -4,18 +4,22 @@ import {
     IConfigurationModify,
     IHttp,
     ILogger,
+    IModify,
+    IPersistence,
     IRead,
 } from '@rocket.chat/apps-engine/definition/accessors';
 import { ApiSecurity, ApiVisibility } from '@rocket.chat/apps-engine/definition/api';
 import { App } from '@rocket.chat/apps-engine/definition/App';
+import { IMessage, IPostMessageSent } from '@rocket.chat/apps-engine/definition/messages';
 import { IAppInfo } from '@rocket.chat/apps-engine/definition/metadata';
 import { ISetting } from '@rocket.chat/apps-engine/definition/settings';
 import { AppSetting, settings } from './config/Settings';
 import { AuthenticationEndpoint } from './endpoints/AuthenticationEndpoint';
+import { handlePostMessageSentAsync } from './lib/PostMessageSentHandler';
 import { LoginTeamsSlashCommand } from './slashcommands/LoginTeamsSlashCommand';
 import { SetupVerificationSlashCommand } from './slashcommands/SetupVerificationSlashCommand';
 
-export class TeamsBridgeApp extends App {
+export class TeamsBridgeApp extends App implements IPostMessageSent {
     constructor(info: IAppInfo, logger: ILogger, accessors: IAppAccessors) {
         super(info, logger, accessors);
     }
@@ -42,5 +46,14 @@ export class TeamsBridgeApp extends App {
         read: IRead,
         http: IHttp): Promise<void> {
         console.log(`onSettingUpdated for setting ${setting.id} with new value ${setting.value}`);
+    }
+
+    public async executePostMessageSent(
+        message: IMessage,
+        read: IRead,
+        http: IHttp,
+        persistence: IPersistence,
+        modify: IModify): Promise<void> {
+        await handlePostMessageSentAsync(message, read, http, persistence, modify);
     }
 }

--- a/app.json
+++ b/app.json
@@ -16,5 +16,7 @@
         "Communication",
         "Omnichannel"
     ],
-    "implements": []
+    "implements": [
+        "IPostMessageSent"
+    ]
 }

--- a/docs/user.md
+++ b/docs/user.md
@@ -24,10 +24,27 @@ The required action for you to authorize the TeamsBridge App is called `Embedded
 - Click `Yes` if you see the login page ask authorization for specific permissions from you.
 - If you successfully login to Teams and authorize the TeamsBridge App, the web pages will show `Login to Teams succeed! You can close this window now.`. You can just close the window.
 
-## Send Direct Message to a collaborator who use Microsoft Teams
+## Collaboration Experience
 
-Document under development.
+One of the most important goals of Rocket.Chat TeamsBridge App is to build a smooth user experience for both users on Rocket.Chat and Microsoft Teams. To achieve this, TeamsBridge App introduces a concept called `Dummy User` in Rocket.Chat world. Each Rocket.Chat `Dummy User` represents a real user on Microsoft Teams. When a Rocket.Chat user that has already `embedded login` to his Teams account sends a message to a `Dummy User`, the message will be delivered to Microsoft Teams world with the original sender's Teams account as the sender and the `Dummy User`'s corresponding Teams account as the receiver. As a result, from the Rocket.Chat users' perspective, they are just collaborating with someone on Rocket.Chat. Meanwhile, from the Teams users' perspective, they are just messaging someone on Teams. With the `Dummy User` approach, the TeamsBridge App delivers messages between Rocket.Chat and Microsoft Teams while keeping the orginal collaboration experience for users on both platforms.
 
-## Send Message to a group chat with participant(s) who use Microsoft Teams
+### Send one on one Direct Message to a collaborator who use Microsoft Teams
 
-Document under development.
+To send a one on one Direct Message from Rocket.Chat to a collaborator who use Microsoft Teams, the Rocket.Chat user just need to search the `Dummy User` that represent the Teams user in Rocket.Chat client and send a message to them. The message will be delivered to Microsoft Teams world with the original sender's Teams account as the sender and the `Dummy User`'s corresponding Teams account as the receiver.
+
+### Receive one on one Direct Message from a collaborator who use Microsoft Teams
+
+This feature is under development and will be available soon.
+
+### Send Message to a group chat with participant(s) who use Microsoft Teams
+
+Currently, this is NOT a supported scenario, which is under developer and will be added soon in the future.
+
+### Receive Message in a group chat with participant(s) who use Microsoft Teams
+
+This feature is under development and will be available soon.
+
+### Supported Message Types
+
+Currently, the following message types are supported:
+- Text Message

--- a/endpoints/AuthenticationEndpoint.ts
+++ b/endpoints/AuthenticationEndpoint.ts
@@ -58,7 +58,13 @@ export class AuthenticationEndpoint extends ApiEndpoint {
                 aadClientId,
                 aadClientSecret);
 
-            await persistUserAccessTokenAsync(persis, rocketChatUserId, response.accessToken, response.refreshToken as string);
+            await persistUserAccessTokenAsync(
+                persis,
+                rocketChatUserId,
+                response.accessToken,
+                response.refreshToken as string,
+                response.expiresIn,
+                response.extExpiresIn);
 
             // TODO: setup token refresh mechenism in future PR
             // TODO: setup incoming message webhook in future PR

--- a/endpoints/AuthenticationEndpoint.ts
+++ b/endpoints/AuthenticationEndpoint.ts
@@ -15,8 +15,8 @@ import { IApiResponseJSON } from "@rocket.chat/apps-engine/definition/api/IRespo
 import { IApp } from "@rocket.chat/apps-engine/definition/IApp";
 import { AppSetting } from "../config/Settings";
 import { AuthenticationEndpointPath } from "../lib/Const";
-import { getUserAccessTokenAsync } from "../lib/MicrosoftGraphApi";
-import { persistUserAccessTokenAsync } from "../lib/PersistHelper";
+import { getUserAccessTokenAsync, getUserProfileAsync } from "../lib/MicrosoftGraphApi";
+import { persistUserAccessTokenAsync, persistUserAsync } from "../lib/PersistHelper";
 import { getRocketChatAppEndpointUrl } from "../lib/UrlHelper";
 
 export class AuthenticationEndpoint extends ApiEndpoint {
@@ -58,13 +58,19 @@ export class AuthenticationEndpoint extends ApiEndpoint {
                 aadClientId,
                 aadClientSecret);
 
+            const userAccessToken = response.accessToken;
+
+            const teamsUserProfile = await getUserProfileAsync(http, userAccessToken);
+
             await persistUserAccessTokenAsync(
                 persis,
                 rocketChatUserId,
-                response.accessToken,
+                userAccessToken,
                 response.refreshToken as string,
                 response.expiresIn,
                 response.extExpiresIn);
+
+            await persistUserAsync(persis, rocketChatUserId, teamsUserProfile.id);
 
             // TODO: setup token refresh mechenism in future PR
             // TODO: setup incoming message webhook in future PR

--- a/lib/Const.ts
+++ b/lib/Const.ts
@@ -1,15 +1,33 @@
-import { DummyUserModel } from "./PersistHelper";
+import { UserModel } from "./PersistHelper";
 
 export const AuthenticationEndpointPath: string = 'auth';
 
-export const MicrosoftBaseUrl: string = 'https://login.microsoftonline.com';
+const LoginBaseUrl: string = 'https://login.microsoftonline.com';
+const GraphApiBaseUrl: string = 'https://graph.microsoft.com';
+export const SupportDocumentUrl: string = 'https://github.com/RocketChat/Apps.teams.bridge/blob/main/docs/support.md';
+
+const GraphApiVersion = {
+    V1: 'v1.0',
+    Beta: 'beta',
+}
+
+const GraphApiEndpoint = {
+    Profile: 'me',
+    Chat: 'chats',
+    Message: (threadId: string) => `chats/${threadId}/messages`,
+};
 
 export const LoginMessageText: string =
     'To start cross platform collaboration, you need to login to Microsoft with your Teams account or guest account. '
     + 'You\'ll be able to keep using Rocket.Chat, but you\'ll also be able to chat with colleagues using Microsoft Teams. '
     + 'Please click this button to login Teams:';
+export const LoginRequiredHintMessageText: string = 
+    'The Rocket.Chat user you are messaging represents a colleague in your organization using Microsoft Teams. '
+    + 'The message can NOT be delivered to the user on Microsoft Teams before you start cross platform collaboration for your account. '
+    + 'For details, see:';
 
 export const LoginButtonText: string = 'Login Teams';
+export const SupportDocumentButtonText: string = 'Support Document';
 
 export const AuthenticationScopes = [
     'offline_access',
@@ -24,11 +42,23 @@ export const AuthenticationScopes = [
 ];
 
 export const getMicrosoftTokenUrl = (aadTenantId: string) => {
-    return `${MicrosoftBaseUrl}/${aadTenantId}/oauth2/v2.0/token`;
+    return `${LoginBaseUrl}/${aadTenantId}/oauth2/v2.0/token`;
 };
 
 export const getMicrosoftAuthorizeUrl = (aadTenantId: string) => {
-    return `${MicrosoftBaseUrl}/${aadTenantId}/oauth2/v2.0/authorize`;
+    return `${LoginBaseUrl}/${aadTenantId}/oauth2/v2.0/authorize`;
+};
+
+export const getGraphApiProfileUrl = () => {
+    return `${GraphApiBaseUrl}/${GraphApiVersion.V1}/${GraphApiEndpoint.Profile}`;
+};
+
+export const getGraphApiChatUrl = () => {
+    return `${GraphApiBaseUrl}/${GraphApiVersion.V1}/${GraphApiEndpoint.Chat}`;
+};
+
+export const getGraphApiMessageUrl = (threadId: string) => {
+    return `${GraphApiBaseUrl}/${GraphApiVersion.V1}/${GraphApiEndpoint.Message(threadId)}`;
 };
 
 export const TestEnvironment = {
@@ -39,8 +69,8 @@ export const TestEnvironment = {
     mockDummyUsers: [
         {
             // Mock dummy user for alexw.l4cf.onmicrosoft.com 
-            rocketChatUserId: 'WDWqKXJCRiRKTR7k8',
+            rocketChatUserId: 'v4ECCH3pTAE6nBXyJ',
             teamsUserId: 'ffa3322f-670c-4887-b193-a04cca6073f8',
         }
-    ] as DummyUserModel[],
+    ] as UserModel[],
 };

--- a/lib/Const.ts
+++ b/lib/Const.ts
@@ -1,3 +1,5 @@
+import { DummyUserModel } from "./PersistHelper";
+
 export const AuthenticationEndpointPath: string = 'auth';
 
 export const MicrosoftBaseUrl: string = 'https://login.microsoftonline.com';
@@ -27,4 +29,18 @@ export const getMicrosoftTokenUrl = (aadTenantId: string) => {
 
 export const getMicrosoftAuthorizeUrl = (aadTenantId: string) => {
     return `${MicrosoftBaseUrl}/${aadTenantId}/oauth2/v2.0/authorize`;
+};
+
+export const TestEnvironment = {
+    // Set enable to true for local testing with mock data
+    enable: true,
+    // Put url here when running locally & using tunnel service such as Ngrok to expose the localhost port to the internet
+    tunnelServiceUrl: '',
+    mockDummyUsers: [
+        {
+            // Mock dummy user for alexw.l4cf.onmicrosoft.com 
+            rocketChatUserId: 'WDWqKXJCRiRKTR7k8',
+            teamsUserId: 'ffa3322f-670c-4887-b193-a04cca6073f8',
+        }
+    ] as DummyUserModel[],
 };

--- a/lib/MicrosoftGraphApi.ts
+++ b/lib/MicrosoftGraphApi.ts
@@ -96,3 +96,7 @@ export const getUserAccessTokenAsync = async (
         throw new Error(`Get application access token failed with http status code ${response.statusCode}.`);
     }
 };
+
+export const getUserInfomationAsync = async () : Promise<void> => {
+
+};

--- a/lib/MicrosoftGraphApi.ts
+++ b/lib/MicrosoftGraphApi.ts
@@ -3,7 +3,13 @@ import {
     IHttp,
     IHttpRequest,
 } from "@rocket.chat/apps-engine/definition/accessors";
-import { AuthenticationScopes, getMicrosoftTokenUrl } from "./Const";
+import {
+    AuthenticationScopes,
+    getGraphApiChatUrl,
+    getGraphApiMessageUrl,
+    getGraphApiProfileUrl,
+    getMicrosoftTokenUrl
+} from "./Const";
 
 export interface TokenResponse {
     tokenType: string;
@@ -11,6 +17,22 @@ export interface TokenResponse {
     extExpiresIn: number;
     accessToken: string;
     refreshToken?: string;
+};
+
+export interface TeamsUserProfile {
+    displayName: string;
+    givenName: string;
+    surname: string;
+    mail: string;
+    id: string;
+};
+
+export interface CreateThreadResponse {
+    threadId: string;
+};
+
+export interface SendMessageResponse {
+    messageId: string;
 };
 
 export const getApplicationAccessTokenAsync = async (
@@ -68,7 +90,7 @@ export const getUserAccessTokenAsync = async (
     
     const httpRequest: IHttpRequest = {
         headers: {
-            "Content-Type": "application/x-www-form-urlencoded"
+            'Content-Type': 'application/x-www-form-urlencoded'
         },
         content: body
     };
@@ -97,6 +119,123 @@ export const getUserAccessTokenAsync = async (
     }
 };
 
-export const getUserInfomationAsync = async () : Promise<void> => {
+export const getUserProfileAsync = async (http: IHttp, userAccessToken: string) : Promise<TeamsUserProfile> => {
+    const url = getGraphApiProfileUrl();
+    const httpRequest: IHttpRequest = {
+        headers: {
+            'Authorization': `Bearer ${userAccessToken}`,
+        },
+    };
 
+    const response = await http.get(url, httpRequest);
+
+    if (response.statusCode === HttpStatusCode.OK) {
+        const responseBody = response.content;
+        if (responseBody === undefined) {
+            throw new Error('Get user profile failed!');
+        }
+
+        const jsonBody = JSON.parse(responseBody);
+        const result : TeamsUserProfile = {
+            displayName: jsonBody.displayName,
+            givenName: jsonBody.givenName,
+            surname: jsonBody.surname,
+            mail: jsonBody.mail,
+            id: jsonBody.id,
+        };
+
+        return result;
+    } else {
+        throw new Error(`Get user profile failed with http status code ${response.statusCode}.`);
+    }
+};
+
+export const createOneOnOneChatThreadAsync = async (
+    http: IHttp,
+    senderUserTeamsId: string,
+    receiverUserTeamsId: string,
+    userAccessToken: string) : Promise<CreateThreadResponse> => {
+    const url = getGraphApiChatUrl();
+
+    const body = {
+        'chatType': 'oneOnOne',
+        'members': [
+            {
+                '@odata.type': '#microsoft.graph.aadUserConversationMember',
+                'roles': ['owner'],
+                'user@odata.bind': `https://graph.microsoft.com/v1.0/users('${senderUserTeamsId}')`,
+            },
+            {
+                '@odata.type': '#microsoft.graph.aadUserConversationMember',
+                'roles': ['owner'],
+                'user@odata.bind': `https://graph.microsoft.com/v1.0/users('${receiverUserTeamsId}')`,
+            },
+        ],
+    }
+
+    const httpRequest: IHttpRequest = {
+        headers: {
+            'Content-Type': 'application/json',
+            'Authorization': `Bearer ${userAccessToken}`,
+        },
+        content: JSON.stringify(body)
+    };
+
+    const response = await http.post(url, httpRequest);
+
+    if (response.statusCode === HttpStatusCode.CREATED) {
+        const responseBody = response.content;
+        if (responseBody === undefined) {
+            throw new Error('Create one on one chat thread failed!');
+        }
+
+        const jsonBody = JSON.parse(responseBody);
+        const result : CreateThreadResponse = {
+            threadId: jsonBody.id,
+        };
+
+        return result;
+    } else {
+        throw new Error(`Create one on one chat thread failed with http status code ${response.statusCode}.`);
+    }
+};
+
+export const sendTextMessageToChatThreadAsync = async (
+    http: IHttp,
+    textMessage: string,
+    threadId: string,
+    userAccessToken: string) : Promise<SendMessageResponse> => {
+    const url = getGraphApiMessageUrl(threadId);
+
+    const body = {
+        'body' : {
+            'content': textMessage
+        }
+    }
+
+    const httpRequest: IHttpRequest = {
+        headers: {
+            'Content-Type': 'application/json',
+            'Authorization': `Bearer ${userAccessToken}`,
+        },
+        content: JSON.stringify(body)
+    };
+
+    const response = await http.post(url, httpRequest);
+
+    if (response.statusCode === HttpStatusCode.CREATED) {
+        const responseBody = response.content;
+        if (responseBody === undefined) {
+            throw new Error('Send message to chat thread failed!');
+        }
+
+        const jsonBody = JSON.parse(responseBody);
+        const result : SendMessageResponse = {
+            messageId: jsonBody.id,
+        };
+
+        return result;
+    } else {
+        throw new Error(`Send message to chat thread failed with http status code ${response.statusCode}.`);
+    }
 };

--- a/lib/PersistHelper.ts
+++ b/lib/PersistHelper.ts
@@ -5,6 +5,7 @@ import { TestEnvironment } from "./Const";
 const MiscKeys = {
     ApplicationAccessToken: 'ApplicationAccessToken',
     UserAccessToken: 'UserAccessToken',
+    User: 'User',
     DummyUser: 'DummyUser',
 };
 
@@ -13,14 +14,14 @@ interface ApplicationAccessTokenModel {
 };
 
 interface UserAccessTokenModel {
-    userId: string,
+    rocketChatUserId: string,
     accessToken: string,
     refreshToken: string,
     expires: number,
     extExpires: number,
 };
 
-export interface DummyUserModel {
+export interface UserModel {
     rocketChatUserId: string,
     teamsUserId: string,
 };
@@ -40,21 +41,21 @@ export const persistApplicationAccessTokenAsync = async (
 
 export const persistUserAccessTokenAsync = async (
     persis: IPersistence,
-    userId: string,
+    rocketChatUserId: string,
     accessToken: string,
     refreshToken: string,
     expiresIn: number,
     extExpiresIn: number) : Promise<void> => {
     const associations: Array<RocketChatAssociationRecord> = [
         new RocketChatAssociationRecord(RocketChatAssociationModel.MISC, MiscKeys.UserAccessToken),
-        new RocketChatAssociationRecord(RocketChatAssociationModel.USER, userId),
+        new RocketChatAssociationRecord(RocketChatAssociationModel.USER, rocketChatUserId),
     ];
 
     const now = new Date();
     const epochInSecond = Math.round(now.getTime() / 1000);
 
     const data : UserAccessTokenModel = {
-        userId: userId,
+        rocketChatUserId: rocketChatUserId,
         accessToken: accessToken,
         refreshToken: refreshToken,
         expires: epochInSecond + expiresIn,
@@ -72,7 +73,23 @@ export const persistDummyUserAsync = async (
         new RocketChatAssociationRecord(RocketChatAssociationModel.MISC, MiscKeys.DummyUser),
         new RocketChatAssociationRecord(RocketChatAssociationModel.USER, rocketChatUserId),
     ];
-    const data : DummyUserModel = {
+    const data : UserModel = {
+        rocketChatUserId: rocketChatUserId,
+        teamsUserId: teamsUserId,
+    };
+
+    await persis.updateByAssociations(associations, data, true);
+};
+
+export const persistUserAsync = async (
+    persis: IPersistence,
+    rocketChatUserId: string,
+    teamsUserId: string) : Promise<void> => {
+    const associations: Array<RocketChatAssociationRecord> = [
+        new RocketChatAssociationRecord(RocketChatAssociationModel.MISC, MiscKeys.User),
+        new RocketChatAssociationRecord(RocketChatAssociationModel.USER, rocketChatUserId),
+    ];
+    const data : UserModel = {
         rocketChatUserId: rocketChatUserId,
         teamsUserId: teamsUserId,
     };
@@ -90,7 +107,7 @@ export const checkDummyUserAsync = async (read: IRead, userId: string) : Promise
     return true;
 };
 
-export const retrieveDummyUserAsync = async (read: IRead, userId: string) : Promise<DummyUserModel | null> => {
+export const retrieveDummyUserAsync = async (read: IRead, userId: string) : Promise<UserModel | null> => {
     // Mock dummy user before find out how to create user with Rocket.Chat Apps Engine
     if (TestEnvironment.enable) {
         const mockDummyUser = TestEnvironment.mockDummyUsers.filter(user => user.rocketChatUserId === userId);
@@ -115,7 +132,28 @@ export const retrieveDummyUserAsync = async (read: IRead, userId: string) : Prom
         throw new Error(`More than one DummyUser record for user ${userId}`);
     }
 
-    const data : DummyUserModel = results[0] as DummyUserModel;
+    const data : UserModel = results[0] as UserModel;
+    return data;
+};
+
+export const retrieveUserAsync = async (read: IRead, userId: string) : Promise<UserModel | null> => {
+    const associations: Array<RocketChatAssociationRecord> = [
+        new RocketChatAssociationRecord(RocketChatAssociationModel.MISC, MiscKeys.User),
+        new RocketChatAssociationRecord(RocketChatAssociationModel.USER, userId),
+    ];
+
+    const persistenceRead : IPersistenceRead = read.getPersistenceReader();
+    const results = await persistenceRead.readByAssociations(associations);
+
+    if (results === undefined || results === null || results.length == 0) {
+        return null;
+    }
+
+    if (results.length > 1) {
+        throw new Error(`More than one User record for user ${userId}`);
+    }
+
+    const data : UserModel = results[0] as UserModel;
     return data;
 };
 
@@ -141,9 +179,7 @@ export const retrieveUserAccessTokenAsync = async (read: IRead, userId: string) 
     const now = new Date();
     const epochInSecond = Math.round(now.getTime() / 1000);
 
-    console.log(data);
-
-    if (epochInSecond > data.expires) {
+    if (!data.expires || epochInSecond > data.expires) {
         return null;
     }
 

--- a/lib/PersistHelper.ts
+++ b/lib/PersistHelper.ts
@@ -1,9 +1,11 @@
-import { IPersistence } from "@rocket.chat/apps-engine/definition/accessors";
+import { IPersistence, IPersistenceRead, IRead } from "@rocket.chat/apps-engine/definition/accessors";
 import { RocketChatAssociationModel, RocketChatAssociationRecord } from "@rocket.chat/apps-engine/definition/metadata";
+import { TestEnvironment } from "./Const";
 
 const MiscKeys = {
     ApplicationAccessToken: 'ApplicationAccessToken',
     UserAccessToken: 'UserAccessToken',
+    DummyUser: 'DummyUser',
 };
 
 interface ApplicationAccessTokenModel {
@@ -14,6 +16,13 @@ interface UserAccessTokenModel {
     userId: string,
     accessToken: string,
     refreshToken: string,
+    expires: number,
+    extExpires: number,
+};
+
+export interface DummyUserModel {
+    rocketChatUserId: string,
+    teamsUserId: string,
 };
 
 export const persistApplicationAccessTokenAsync = async (
@@ -33,16 +42,110 @@ export const persistUserAccessTokenAsync = async (
     persis: IPersistence,
     userId: string,
     accessToken: string,
-    refreshToken: string) : Promise<void> => {
+    refreshToken: string,
+    expiresIn: number,
+    extExpiresIn: number) : Promise<void> => {
     const associations: Array<RocketChatAssociationRecord> = [
         new RocketChatAssociationRecord(RocketChatAssociationModel.MISC, MiscKeys.UserAccessToken),
         new RocketChatAssociationRecord(RocketChatAssociationModel.USER, userId),
     ];
+
+    const now = new Date();
+    const epochInSecond = Math.round(now.getTime() / 1000);
+
     const data : UserAccessTokenModel = {
         userId: userId,
         accessToken: accessToken,
         refreshToken: refreshToken,
+        expires: epochInSecond + expiresIn,
+        extExpires: epochInSecond + extExpiresIn,
     };
 
     await persis.updateByAssociations(associations, data, true);
+};
+
+export const persistDummyUserAsync = async (
+    persis: IPersistence,
+    rocketChatUserId: string,
+    teamsUserId: string) : Promise<void> => {
+    const associations: Array<RocketChatAssociationRecord> = [
+        new RocketChatAssociationRecord(RocketChatAssociationModel.MISC, MiscKeys.DummyUser),
+        new RocketChatAssociationRecord(RocketChatAssociationModel.USER, rocketChatUserId),
+    ];
+    const data : DummyUserModel = {
+        rocketChatUserId: rocketChatUserId,
+        teamsUserId: teamsUserId,
+    };
+
+    await persis.updateByAssociations(associations, data, true);
+};
+
+export const checkDummyUserAsync = async (read: IRead, userId: string) : Promise<boolean> => {
+    const data = await retrieveDummyUserAsync(read, userId);
+    
+    if (data === undefined || data === null) {
+        return false;
+    }
+
+    return true;
+};
+
+export const retrieveDummyUserAsync = async (read: IRead, userId: string) : Promise<DummyUserModel | null> => {
+    // Mock dummy user before find out how to create user with Rocket.Chat Apps Engine
+    if (TestEnvironment.enable) {
+        const mockDummyUser = TestEnvironment.mockDummyUsers.filter(user => user.rocketChatUserId === userId);
+        if (mockDummyUser && mockDummyUser.length === 1) {
+            return mockDummyUser[0];
+        }
+    }
+
+    const associations: Array<RocketChatAssociationRecord> = [
+        new RocketChatAssociationRecord(RocketChatAssociationModel.MISC, MiscKeys.DummyUser),
+        new RocketChatAssociationRecord(RocketChatAssociationModel.USER, userId),
+    ];
+
+    const persistenceRead : IPersistenceRead = read.getPersistenceReader();
+    const results = await persistenceRead.readByAssociations(associations);
+
+    if (results === undefined || results === null || results.length == 0) {
+        return null;
+    }
+
+    if (results.length > 1) {
+        throw new Error(`More than one DummyUser record for user ${userId}`);
+    }
+
+    const data : DummyUserModel = results[0] as DummyUserModel;
+    return data;
+};
+
+export const retrieveUserAccessTokenAsync = async (read: IRead, userId: string) : Promise<string | null> => {
+    const associations: Array<RocketChatAssociationRecord> = [
+        new RocketChatAssociationRecord(RocketChatAssociationModel.MISC, MiscKeys.UserAccessToken),
+        new RocketChatAssociationRecord(RocketChatAssociationModel.USER, userId),
+    ];
+
+    const persistenceRead : IPersistenceRead = read.getPersistenceReader();
+    const results = await persistenceRead.readByAssociations(associations);
+
+    if (results === undefined || results === null || results.length == 0) {
+        return null;
+    }
+
+    if (results.length > 1) {
+        throw new Error(`More than one UserAccessToken record for user ${userId}`);
+    }
+
+    const data : UserAccessTokenModel = results[0] as UserAccessTokenModel;
+
+    const now = new Date();
+    const epochInSecond = Math.round(now.getTime() / 1000);
+
+    console.log(data);
+
+    if (epochInSecond > data.expires) {
+        return null;
+    }
+
+    return data.accessToken;
 };

--- a/lib/PostMessageSentHandler.ts
+++ b/lib/PostMessageSentHandler.ts
@@ -1,0 +1,76 @@
+import { IHttp, IModify, IPersistence, IRead } from "@rocket.chat/apps-engine/definition/accessors";
+import { IMessage } from "@rocket.chat/apps-engine/definition/messages";
+import { IRoom, RoomType } from "@rocket.chat/apps-engine/definition/rooms";
+import { IUser } from "@rocket.chat/apps-engine/definition/users";
+import { nofityRocketChatUserInRoomAsync } from "./Messages";
+import { checkDummyUserAsync, retrieveDummyUserAsync, retrieveUserAccessTokenAsync } from "./PersistHelper";
+
+export const handlePostMessageSentAsync = async (
+    message: IMessage,
+    read: IRead,
+    http: IHttp,
+    persistence: IPersistence,
+    modify: IModify) : Promise<void> => {
+    // In first version, we'll only support sending text message in 1:1 chat with Teams user
+
+    // If the message is not a text message, stop processing
+    if (!isTextMessage(message)) {
+        return;
+    }
+
+    // If the message is not sent in a 1:1 chat, stop processing
+    const room = message.room;
+    if (!isOneOnOneChat(room)) {
+        return;
+    }
+
+    // If the message receiver is not a Teams Dummy user, stop processing
+    const receiverId = getDirectMessageReceiverId(message, room);
+    if (receiverId === undefined) {
+        return;
+    }
+    const isReceiverDummyUser = await checkDummyUserAsync(read, receiverId);
+    if (!isReceiverDummyUser) {
+        return;
+    }
+
+    // If the message sender has not logged in to Teams
+    // Send a notification to let the sender know he need to logged in to Teams to start cross platform collaboration
+    const senderId = message.sender.id;
+    const senderUserAccessToken = await retrieveUserAccessTokenAsync(read, senderId);
+    if (senderUserAccessToken === null) {
+        await notifyNotLoggedInUserAsync(read, message.sender, room, modify);
+        return;
+    }
+
+    // All checks passed, find the dummy user record
+    const dummyUser = await retrieveDummyUserAsync(read, receiverId);
+};
+
+const notifyNotLoggedInUserAsync = async (read: IRead, user: IUser, room: IRoom, modify: IModify) : Promise<void> => {
+    const errorHintMessage = 'The Rocket.Chat user you are messaging represents a colleague in your organization using Microsoft Teams. '
+    + 'The message can NOT be delivered to the user on Microsoft Teams before you start cross platform collaboration for your account. '
+    + 'For details, see https://github.com/RocketChat/Apps.teams.bridge/blob/main/docs/support.md.';
+    const appUser = (await read.getUserReader().getAppUser()) as IUser;
+    await nofityRocketChatUserInRoomAsync(errorHintMessage, appUser, user, room, modify);
+};
+
+const getDirectMessageReceiverId = (message: IMessage, room: IRoom) : string | undefined => {
+    return room.userIds?.find(id => id !== message.sender.id);
+};
+
+const isOneOnOneChat = (room: IRoom) : boolean => {
+    if (room.type === RoomType.DIRECT_MESSAGE && room.userIds && room.userIds.length === 2) {
+        return true;
+    }
+
+    return false;
+};
+
+const isTextMessage = (message: IMessage) : boolean => {
+    if (message.text) {
+        return true;
+    }
+
+    return false;
+};

--- a/lib/UrlHelper.ts
+++ b/lib/UrlHelper.ts
@@ -1,8 +1,6 @@
 import { IAppAccessors } from "@rocket.chat/apps-engine/definition/accessors";
 import { IApiEndpointMetadata } from "@rocket.chat/apps-engine/definition/api";
-
-// Put url here when running locally & using tunnel service such as Ngrok to expose the localhost port to the internet
-const tunnelServiceUrl: string = '';
+import { TestEnvironment } from "./Const";
 
 export const getRocketChatAppEndpointUrl = async (appAccessors: IAppAccessors, appEndpointPath: string) : Promise<string> => {
 
@@ -11,8 +9,8 @@ export const getRocketChatAppEndpointUrl = async (appAccessors: IAppAccessors, a
     let siteUrl: string = await appAccessors.environmentReader.getServerSettings().getValueById('Site_Url');
     siteUrl = siteUrl.substring(0, siteUrl.length - 1);
     
-    if (tunnelServiceUrl && tunnelServiceUrl !== '') {
-        siteUrl = tunnelServiceUrl;
+    if (TestEnvironment.tunnelServiceUrl && TestEnvironment.tunnelServiceUrl !== '') {
+        siteUrl = TestEnvironment.tunnelServiceUrl;
     }
 
     return siteUrl + webhookEndpoint.computedPath;

--- a/slashcommands/LoginTeamsSlashCommand.ts
+++ b/slashcommands/LoginTeamsSlashCommand.ts
@@ -38,6 +38,8 @@ export class LoginTeamsSlashCommand implements ISlashCommand {
         const loginUrl = this.getLoginUrl(aadTenantId, aadClientId, authEndpointUrl, commandSender.id);
         const appUser = (await read.getUserReader().getAppUser()) as IUser;
 
+        // TODO: check whether current user has already logged in
+        // If the user has already logged, print some other information instead of the login url
         const message = this.getLoginMessageWithButton(loginUrl, appUser, room);
 
         await nofityRocketChatUserAsync(message, commandSender, modify);

--- a/slashcommands/LoginTeamsSlashCommand.ts
+++ b/slashcommands/LoginTeamsSlashCommand.ts
@@ -2,7 +2,7 @@ import { IRead, IModify, IHttp, IPersistence } from "@rocket.chat/apps-engine/de
 import { ISlashCommand, SlashCommandContext } from "@rocket.chat/apps-engine/definition/slashcommands";
 import { IUser } from "@rocket.chat/apps-engine/definition/users";
 import { AppSetting } from "../config/Settings";
-import { nofityRocketChatUserAsync, nofityRocketChatUserInRoomAsync } from "../lib/Messages";
+import { nofityRocketChatUserAsync } from "../lib/Messages";
 import { AuthenticationEndpointPath, AuthenticationScopes, getMicrosoftAuthorizeUrl, LoginButtonText, LoginMessageText } from "../lib/Const";
 import { getRocketChatAppEndpointUrl } from "../lib/UrlHelper";
 import { TeamsBridgeApp } from "../TeamsBridgeApp";


### PR DESCRIPTION
- Update App to implements IPostMessageSent to delivery message to Teams if the receiver is a `Dummy User`.
   - In this first version, only Text messages in one-on-one chat is supported.
- Add corresponding required Microsoft Graph API implementation for outbound message.
- Add corresponding required Rocket.Chat persist related functions for outbound message.
- Add Mock setups for `Dummy User`. This will be there for testing before we figure out the user creation via Apps-Engine.
- Add corresponding document.