### PR TITLE
[FIX] The authentication message is blocking the channel

### DIFF
--- a/lib/EventHandler.ts
+++ b/lib/EventHandler.ts
@@ -2,11 +2,15 @@ import {
     IHttp,
     IModify,
     IPersistence,
-    IRead
+    IRead,
 } from "@rocket.chat/apps-engine/definition/accessors";
 import { UserNotAllowedException } from "@rocket.chat/apps-engine/definition/exceptions";
 import { IMessage } from "@rocket.chat/apps-engine/definition/messages";
-import { IRoom, IRoomUserLeaveContext, RoomType } from "@rocket.chat/apps-engine/definition/rooms";
+import {
+    IRoom,
+    IRoomUserLeaveContext,
+    RoomType,
+} from "@rocket.chat/apps-engine/definition/rooms";
 import { IFileUploadContext } from "@rocket.chat/apps-engine/definition/uploads";
 import { IUser } from "@rocket.chat/apps-engine/definition/users";
 import { AppSetting } from "../config/Settings";
@@ -20,13 +24,13 @@ import {
     LoggedInBridgeUserRequiredHintMessageText,
     LoginRequiredHintMessageText,
     SubscriberEndpointPath,
-    UnsupportedScenarioHintMessageText
+    UnsupportedScenarioHintMessageText,
 } from "./Const";
 import {
     generateHintMessageWithTeamsLoginButton,
     mapRocketChatMessageToTeamsMessage,
     notifyRocketChatUserAsync,
-    notifyRocketChatUserInRoomAsync
+    notifyRocketChatUserInRoomAsync,
 } from "./MessageHelper";
 import {
     addMemberToChatThreadAsync,
@@ -43,7 +47,7 @@ import {
     shareOneDriveFileAsync,
     subscribeToAllMessagesForOneUserAsync,
     updateTextMessageInChatThreadAsync,
-    uploadFileToOneDriveAsync
+    uploadFileToOneDriveAsync,
 } from "./MicrosoftGraphApi";
 import {
     checkDummyUserByRocketChatUserIdAsync,
@@ -54,13 +58,15 @@ import {
     retrieveAllUserRegistrationsAsync,
     retrieveDummyUserByRocketChatUserIdAsync,
     retrieveDummyUserByTeamsUserIdAsync,
+    retrieveLoginMessageSentStatus,
     retrieveMessageIdMappingByRocketChatMessageIdAsync,
     retrieveOneDriveFileAsync,
     retrieveRoomByRocketChatRoomIdAsync,
     retrieveUserAccessTokenAsync,
     retrieveUserByRocketChatUserIdAsync,
     retrieveUserRefreshTokenAsync,
-    UserModel
+    saveLoginMessageSentStatus,
+    UserModel,
 } from "./PersistHelper";
 import { getLoginUrl, getRocketChatAppEndpointUrl } from "./UrlHelper";
 
@@ -68,12 +74,25 @@ export const handlePreMessageSentPreventAsync = async (
     message: IMessage,
     read: IRead,
     persistence: IPersistence,
-    app: TeamsBridgeApp) : Promise<boolean> => {
+    app: TeamsBridgeApp
+): Promise<boolean> => {
+    const wasSent = await retrieveLoginMessageSentStatus({
+        read,
+        rocketChatUserId: message.sender.id,
+    });
+
+    if (wasSent) {
+        return false;
+    }
+
     const appUser = (await read.getUserReader().getAppUser()) as IUser;
     const notifier = read.getNotifier();
 
     if (message.threadId) {
-        const isTeamsMessageThread = await isTeamsMessageAsync(message.threadId, read);
+        const isTeamsMessageThread = await isTeamsMessageAsync(
+            message.threadId,
+            read
+        );
         if (isTeamsMessageThread) {
             // There's no thread message concept in Teams
             // Thread message is not a supported scenario for Teams interop
@@ -83,32 +102,44 @@ export const handlePreMessageSentPreventAsync = async (
                 appUser,
                 message.sender,
                 message.room,
-                notifier);
+                notifier
+            );
 
             return true;
         }
     }
 
-    let preventOperation = false;
     const roomType = message.room.type;
-    if (roomType === RoomType.PRIVATE_GROUP || roomType === RoomType.DIRECT_MESSAGE) {
+    if (
+        roomType === RoomType.PRIVATE_GROUP ||
+        roomType === RoomType.DIRECT_MESSAGE
+    ) {
         // If room type is PRIVATE_GROUP or DIRECT_MESSAGE, check if there's any dummy user in the room
         const members = await read.getRoomReader().getMembers(message.room.id);
 
-        const dummyUsers = await findAllDummyUsersInRocketChatUserListAsync(read, members);
+        const dummyUsers = await findAllDummyUsersInRocketChatUserListAsync(
+            read,
+            members
+        );
 
         if (dummyUsers && dummyUsers.length > 0) {
             // If there are dummy users in the room, check whether there's at least one teams-logged in user in this room
 
             // Find whether there's an existing room record
-            let roomRecord = await retrieveRoomByRocketChatRoomIdAsync(read, message.room.id);
+            let roomRecord = await retrieveRoomByRocketChatRoomIdAsync(
+                read,
+                message.room.id
+            );
 
             if (roomRecord) {
                 // If there's an existing room record, check whether it has a bridge user
                 if (roomRecord.bridgeUserRocketChatUserId) {
                     // If this room already has assigned a bridge user, check the bridge user login status
 
-                    const accessToken = await retrieveUserAccessTokenAsync(read, roomRecord.bridgeUserRocketChatUserId);
+                    const accessToken = await retrieveUserAccessTokenAsync(
+                        read,
+                        roomRecord.bridgeUserRocketChatUserId
+                    );
                     if (!accessToken) {
                         // If the existing bridge user is logged out, clean the bridge user
                         roomRecord.bridgeUserRocketChatUserId = undefined;
@@ -123,33 +154,75 @@ export const handlePreMessageSentPreventAsync = async (
 
             // Try to find a logged in user and assign to the room as the bridge user
             if (!roomRecord.bridgeUserRocketChatUserId) {
-                const loggedInUser = await findOneTeamsLoggedInUsersAsync(read, members);
-                const isOneOnOneDirectMessage = roomType === RoomType.DIRECT_MESSAGE && members.length === 2;
+                const loggedInUser = await findOneTeamsLoggedInUsersAsync(
+                    read,
+                    members
+                );
+                const isOneOnOneDirectMessage =
+                    roomType === RoomType.DIRECT_MESSAGE &&
+                    members.length === 2;
                 if (loggedInUser) {
                     // Assign the room a bridge user
-                    roomRecord.bridgeUserRocketChatUserId = loggedInUser.rocketChatUserId;
-    
+                    roomRecord.bridgeUserRocketChatUserId =
+                        loggedInUser.rocketChatUserId;
+
                     // For 1:1 dm chat, no further action required
                     if (!isOneOnOneDirectMessage) {
                         // For other type of chat room
                         // Notify the bridge user that he has became the bridge of this room
                         // All messages sent by unlogged in user will be delivered to Microsoft Teams by him
-                        const bridgeUser = await read.getUserReader().getById(loggedInUser.rocketChatUserId);
-                        await notifyRocketChatUserInRoomAsync(BridgeUserNotificationMessageText, appUser, bridgeUser, message.room, notifier);
+                        const bridgeUser = await read
+                            .getUserReader()
+                            .getById(loggedInUser.rocketChatUserId);
+                        await notifyRocketChatUserInRoomAsync(
+                            BridgeUserNotificationMessageText,
+                            appUser,
+                            bridgeUser,
+                            message.room,
+                            notifier
+                        );
 
                         // TODO: send a message to Microsoft Teams to let the user there know the bridge user represents some other users
                     }
                 } else {
                     // If there's no logged in user in the room, prevent the message
-                    preventOperation = true;
-    
                     if (isOneOnOneDirectMessage) {
                         // For 1:1 chat, notify the sender to login
-                        await notifyNotLoggedInUserAsync(read, message.sender, message.room, app, LoginRequiredHintMessageText);
+
+                        await Promise.all([
+                            saveLoginMessageSentStatus({
+                                persistence,
+                                rocketChatUserId: message.sender.id,
+                                wasSent: true,
+                            }),
+                            notifyNotLoggedInUserAsync(
+                                read,
+                                message.sender,
+                                message.room,
+                                app,
+                                LoginRequiredHintMessageText
+                            ),
+                        ]);
+
                     } else {
                         // For other type of chat room
                         // Notify the message sender there's no available bridge user
-                        await notifyNotLoggedInUserAsync(read, message.sender, message.room, app, LoggedInBridgeUserRequiredHintMessageText);
+
+                        await Promise.all([
+                            saveLoginMessageSentStatus({
+                                persistence,
+                                rocketChatUserId: message.sender.id,
+                                wasSent: true,
+                            }),
+                            notifyNotLoggedInUserAsync(
+                                read,
+                                message.sender,
+                                message.room,
+                                app,
+                                LoggedInBridgeUserRequiredHintMessageText
+                            ),
+                        ]);
+
                     }
                 }
             }
@@ -159,65 +232,93 @@ export const handlePreMessageSentPreventAsync = async (
                 persistence,
                 roomRecord.rocketChatRoomId,
                 roomRecord.teamsThreadId,
-                roomRecord.bridgeUserRocketChatUserId);
+                roomRecord.bridgeUserRocketChatUserId
+            );
         }
     }
 
-    return preventOperation;
+    return false;
 };
 
 export const handlePostMessageSentAsync = async (
     message: IMessage,
     read: IRead,
     http: IHttp,
-    persistence: IPersistence) : Promise<void> => {
-
-    const isSenderDummyUser = await checkDummyUserByRocketChatUserIdAsync(read, message.sender.id);
+    persistence: IPersistence
+): Promise<void> => {
+    const isSenderDummyUser = await checkDummyUserByRocketChatUserIdAsync(
+        read,
+        message.sender.id
+    );
     if (isSenderDummyUser) {
-        console.log('Message sender is a dummy user, stop processing.');
+        console.log("Message sender is a dummy user, stop processing.");
         return;
     }
 
     const roomId = message.room.id;
     const members = await read.getRoomReader().getMembers(roomId);
 
-    const dummyUsers = await findAllDummyUsersInRocketChatUserListAsync(read, members);
+    const dummyUsers = await findAllDummyUsersInRocketChatUserListAsync(
+        read,
+        members
+    );
     if (dummyUsers && dummyUsers.length > 0) {
         // If there's any dummy user in the room, this is a Teams interop chat room
         // Sanity check has been done in PreMessageSentPrevent for Teams interop scenarios
 
         // There should be a room record in persist with a bridge user assigned
-        const roomRecord = await retrieveRoomByRocketChatRoomIdAsync(read, roomId);
+        const roomRecord = await retrieveRoomByRocketChatRoomIdAsync(
+            read,
+            roomId
+        );
         if (!roomRecord) {
-            throw new Error('No room record find for Teams interop room!');
+            throw new Error("No room record find for Teams interop room!");
         }
 
         if (!roomRecord.bridgeUserRocketChatUserId) {
-            throw new Error('No bridge user assigned to Teams interop room!');
+            throw new Error("No bridge user assigned to Teams interop room!");
         }
 
-        const bridgeUser = await retrieveUserByRocketChatUserIdAsync(read, roomRecord.bridgeUserRocketChatUserId);
-        let userAccessToken = await retrieveUserAccessTokenAsync(read, roomRecord.bridgeUserRocketChatUserId);
+        const bridgeUser = await retrieveUserByRocketChatUserIdAsync(
+            read,
+            roomRecord.bridgeUserRocketChatUserId
+        );
+        let userAccessToken = await retrieveUserAccessTokenAsync(
+            read,
+            roomRecord.bridgeUserRocketChatUserId
+        );
         if (!userAccessToken || !bridgeUser) {
             await persistRoomAsync(
                 persistence,
                 roomRecord.rocketChatRoomId,
                 roomRecord.teamsThreadId,
-                undefined);
-            throw new Error('Invalid bridge user!');
+                undefined
+            );
+            throw new Error("Invalid bridge user!");
         }
 
         if (!roomRecord.teamsThreadId) {
             // Not yet a thread exist in Teams side, create one & persist in room record
-            if (message.room.type === RoomType.DIRECT_MESSAGE && members.length === 2) {
+            if (
+                message.room.type === RoomType.DIRECT_MESSAGE &&
+                members.length === 2
+            ) {
                 // If 1:1 DM, create 1:1 Teams chat thread
-                const response = await createOneOnOneChatThreadAsync(http, bridgeUser.teamsUserId, dummyUsers[0].teamsUserId, userAccessToken);
+                const response = await createOneOnOneChatThreadAsync(
+                    http,
+                    bridgeUser.teamsUserId,
+                    dummyUsers[0].teamsUserId,
+                    userAccessToken
+                );
                 roomRecord.teamsThreadId = response.threadId;
             } else {
                 // If other room type, create Teams group chat thread
                 const teamsIds: string[] = [];
                 for (const member of members) {
-                    const user = await retrieveUserByRocketChatUserIdAsync(read, member.id);
+                    const user = await retrieveUserByRocketChatUserIdAsync(
+                        read,
+                        member.id
+                    );
                     if (user) {
                         teamsIds.push(user.teamsUserId);
                     }
@@ -228,47 +329,66 @@ export const handlePostMessageSentAsync = async (
                 }
 
                 const roomName = message.room.displayName ?? DefaultThreadName;
-                const response = await createChatThreadAsync(http, teamsIds, roomName, userAccessToken);
+                const response = await createChatThreadAsync(
+                    http,
+                    teamsIds,
+                    roomName,
+                    userAccessToken
+                );
                 roomRecord.teamsThreadId = response.threadId;
             }
-            
+
             await persistRoomAsync(
                 persistence,
                 roomRecord.rocketChatRoomId,
                 roomRecord.teamsThreadId,
-                roomRecord.bridgeUserRocketChatUserId);
+                roomRecord.bridgeUserRocketChatUserId
+            );
         }
 
         let messageText = message.text;
         if (!messageText) {
-            messageText = '';
+            messageText = "";
         }
 
-        const isMessageBridged = bridgeUser.rocketChatUserId !== message.sender.id;
-        let originalSenderName = isMessageBridged ? message.sender.name : undefined;
+        const isMessageBridged =
+            bridgeUser.rocketChatUserId !== message.sender.id;
+        let originalSenderName = isMessageBridged
+            ? message.sender.name
+            : undefined;
 
-        const senderUserAccessToken = await retrieveUserAccessTokenAsync(read, message.sender.id);
+        const senderUserAccessToken = await retrieveUserAccessTokenAsync(
+            read,
+            message.sender.id
+        );
         if (senderUserAccessToken) {
             // If message sender already logged in, make the message sent by themselves instead of via the bridge user
             userAccessToken = senderUserAccessToken;
             originalSenderName = undefined;
         }
 
-        let teamsMessageId = '';
-        let rocketChatMessageId = '';
+        let teamsMessageId = "";
+        let rocketChatMessageId = "";
         if (message.file) {
             // If message is a file, use send file operation
-            let textMessage = '';
+            let textMessage = "";
             if (message.attachments && message.attachments[0].description) {
                 textMessage = message.attachments[0].description;
             }
 
-            const oneDriveFile = await retrieveOneDriveFileAsync(read, message.file.name);
+            const oneDriveFile = await retrieveOneDriveFileAsync(
+                read,
+                message.file.name
+            );
             if (!oneDriveFile) {
                 return;
             }
 
-            const shareRecord = await shareOneDriveFileAsync(http, oneDriveFile?.driveItemId, userAccessToken);
+            const shareRecord = await shareOneDriveFileAsync(
+                http,
+                oneDriveFile?.driveItemId,
+                userAccessToken
+            );
 
             // Send the message to the chat thread
             const response = await sendFileMessageToChatThreadAsync(
@@ -277,30 +397,43 @@ export const handlePostMessageSentAsync = async (
                 oneDriveFile.fileName,
                 shareRecord.shareLink,
                 roomRecord.teamsThreadId,
-                userAccessToken);
+                userAccessToken
+            );
 
             teamsMessageId = response.messageId;
             rocketChatMessageId = message.id as string;
         } else {
             // Mapping message content format
-            messageText = mapRocketChatMessageToTeamsMessage(messageText, originalSenderName);
+            messageText = mapRocketChatMessageToTeamsMessage(
+                messageText,
+                originalSenderName
+            );
 
             // Send the message to the chat thread
             const response = await sendTextMessageToChatThreadAsync(
                 http,
                 messageText,
                 roomRecord.teamsThreadId,
-                userAccessToken);
+                userAccessToken
+            );
 
             teamsMessageId = response.messageId;
             rocketChatMessageId = message.id as string;
         }
 
-        await persistMessageIdMappingAsync(persistence, rocketChatMessageId, teamsMessageId, roomRecord.teamsThreadId);
+        await persistMessageIdMappingAsync(
+            persistence,
+            rocketChatMessageId,
+            teamsMessageId,
+            roomRecord.teamsThreadId
+        );
     }
 };
 
-export const handlePreMessageOperationPreventAsync = async (message: IMessage, read: IRead): Promise<boolean> => {
+export const handlePreMessageOperationPreventAsync = async (
+    message: IMessage,
+    read: IRead
+): Promise<boolean> => {
     const isTeamsMessage = await isTeamsMessageAsync(message.id, read);
     if (!isTeamsMessage) {
         return false;
@@ -309,31 +442,48 @@ export const handlePreMessageOperationPreventAsync = async (message: IMessage, r
     // If the user that operate the Teams message has not logged in to Teams
     // Send a notification to let the sender know he need to logged in to Teams to apply the operation
     const senderId = message.sender.id;
-    const dummyUser = await retrieveDummyUserByRocketChatUserIdAsync(read, senderId);
+    const dummyUser = await retrieveDummyUserByRocketChatUserIdAsync(
+        read,
+        senderId
+    );
     if (dummyUser) {
         return false;
     }
 
-    const senderUserAccessToken = await retrieveUserAccessTokenAsync(read, senderId);
+    const senderUserAccessToken = await retrieveUserAccessTokenAsync(
+        read,
+        senderId
+    );
     if (!senderUserAccessToken) {
         return true;
     }
 
     return false;
-}
+};
 
-export const handlePostMessageUpdatedAsync = async (message: IMessage, read: IRead, http: IHttp): Promise<void> => {
+export const handlePostMessageUpdatedAsync = async (
+    message: IMessage,
+    read: IRead,
+    http: IHttp
+): Promise<void> => {
     if (!message || !message.id || !message.text) {
         return;
     }
 
-    const messageIdMapping = await retrieveMessageIdMappingByRocketChatMessageIdAsync(read, message.id);
+    const messageIdMapping =
+        await retrieveMessageIdMappingByRocketChatMessageIdAsync(
+            read,
+            message.id
+        );
     if (!messageIdMapping) {
         return;
     }
 
     const senderId = message.sender.id;
-    const senderUserAccessToken = await retrieveUserAccessTokenAsync(read, senderId);
+    const senderUserAccessToken = await retrieveUserAccessTokenAsync(
+        read,
+        senderId
+    );
     if (!senderUserAccessToken) {
         return;
     }
@@ -343,26 +493,41 @@ export const handlePostMessageUpdatedAsync = async (message: IMessage, read: IRe
         message.text,
         messageIdMapping.teamsMessageId,
         messageIdMapping.teamsThreadId,
-        senderUserAccessToken);
+        senderUserAccessToken
+    );
 };
 
-export const handlePostMessageDeletedAsync = async (message: IMessage, read: IRead, http: IHttp): Promise<void> => {
+export const handlePostMessageDeletedAsync = async (
+    message: IMessage,
+    read: IRead,
+    http: IHttp
+): Promise<void> => {
     if (!message || !message.id || !message.text) {
         return;
     }
 
-    const messageIdMapping = await retrieveMessageIdMappingByRocketChatMessageIdAsync(read, message.id);
+    const messageIdMapping =
+        await retrieveMessageIdMappingByRocketChatMessageIdAsync(
+            read,
+            message.id
+        );
     if (!messageIdMapping) {
         return;
     }
 
     const senderId = message.sender.id;
-    const senderUserAccessToken = await retrieveUserAccessTokenAsync(read, senderId);
+    const senderUserAccessToken = await retrieveUserAccessTokenAsync(
+        read,
+        senderId
+    );
     if (!senderUserAccessToken) {
         return;
     }
-    
-    const senderUser = await retrieveUserByRocketChatUserIdAsync(read, senderId);
+
+    const senderUser = await retrieveUserByRocketChatUserIdAsync(
+        read,
+        senderId
+    );
     if (!senderUser) {
         return;
     }
@@ -372,7 +537,8 @@ export const handlePostMessageDeletedAsync = async (message: IMessage, read: IRe
         senderUser.teamsUserId,
         messageIdMapping.teamsMessageId,
         messageIdMapping.teamsThreadId,
-        senderUserAccessToken);
+        senderUserAccessToken
+    );
 };
 
 export const handlePreFileUploadAsync = async (
@@ -380,63 +546,94 @@ export const handlePreFileUploadAsync = async (
     read: IRead,
     http: IHttp,
     persis: IPersistence,
-    modify: IModify) : Promise<void> => {
+    modify: IModify
+): Promise<void> => {
     const senderRocketChatUserId = context.file.userId;
     const roomId = context.file.rid;
     const fileName = context.file.name;
     const fileMIMEType = context.file.type;
     const fileSize = context.file.size;
 
-    if (fileName.startsWith('thumb-')) {
+    if (fileName.startsWith("thumb-")) {
         // TODO: find a better way to not upload the thumb file for image
         return;
     }
 
-    const isSenderDummerUser = await checkDummyUserByRocketChatUserIdAsync(read, senderRocketChatUserId);
+    const isSenderDummerUser = await checkDummyUserByRocketChatUserIdAsync(
+        read,
+        senderRocketChatUserId
+    );
     if (isSenderDummerUser) {
         return;
     }
 
     const members = await read.getRoomReader().getMembers(roomId);
 
-    const dummyUsers = await findAllDummyUsersInRocketChatUserListAsync(read, members);
+    const dummyUsers = await findAllDummyUsersInRocketChatUserListAsync(
+        read,
+        members
+    );
     if (dummyUsers && dummyUsers.length > 0) {
         // If there's any dummy user in the room, this is a Teams interop chat room
         // Sanity check has been done in PreMessageSentPrevent for Teams interop scenarios
 
         // There should be a room record in persist with a bridge user assigned
-        const roomRecord = await retrieveRoomByRocketChatRoomIdAsync(read, roomId);
+        const roomRecord = await retrieveRoomByRocketChatRoomIdAsync(
+            read,
+            roomId
+        );
         if (!roomRecord) {
-            throw new Error('No room record find for Teams interop room!');
+            throw new Error("No room record find for Teams interop room!");
         }
 
         if (!roomRecord.bridgeUserRocketChatUserId) {
-            throw new Error('No bridge user assigned to Teams interop room!');
+            throw new Error("No bridge user assigned to Teams interop room!");
         }
 
-        const bridgeUser = await retrieveUserByRocketChatUserIdAsync(read, roomRecord.bridgeUserRocketChatUserId);
-        let userAccessToken = await retrieveUserAccessTokenAsync(read, roomRecord.bridgeUserRocketChatUserId);
+        const bridgeUser = await retrieveUserByRocketChatUserIdAsync(
+            read,
+            roomRecord.bridgeUserRocketChatUserId
+        );
+        let userAccessToken = await retrieveUserAccessTokenAsync(
+            read,
+            roomRecord.bridgeUserRocketChatUserId
+        );
         if (!userAccessToken || !bridgeUser) {
             await persistRoomAsync(
                 persis,
                 roomRecord.rocketChatRoomId,
                 roomRecord.teamsThreadId,
-                undefined);
-            throw new Error('Invalid bridge user!');
+                undefined
+            );
+            throw new Error("Invalid bridge user!");
         }
 
-        const senderUserAccessToken = await retrieveUserAccessTokenAsync(read, senderRocketChatUserId);
+        const senderUserAccessToken = await retrieveUserAccessTokenAsync(
+            read,
+            senderRocketChatUserId
+        );
         if (senderUserAccessToken) {
             // If file uploader already logged in, make the file uploaded by themselves instead of via the bridge user
             userAccessToken = senderUserAccessToken;
         }
 
         // Upload the file to One Drive
-        const uploadFileResponse = await uploadFileToOneDriveAsync(http, fileName, fileMIMEType, fileSize, context.content, userAccessToken);
+        const uploadFileResponse = await uploadFileToOneDriveAsync(
+            http,
+            fileName,
+            fileMIMEType,
+            fileSize,
+            context.content,
+            userAccessToken
+        );
 
         // Persist file upload record
         if (uploadFileResponse) {
-            await persistOneDriveFileAsync(persis, uploadFileResponse.fileName, uploadFileResponse.driveItemId);
+            await persistOneDriveFileAsync(
+                persis,
+                uploadFileResponse.fileName,
+                uploadFileResponse.driveItemId
+            );
         }
     }
 };
@@ -449,11 +646,14 @@ export const handleAddTeamsUserContextualBarSubmitAsync = async (
     modify: IModify,
     persis: IPersistence,
     http: IHttp,
-    app: TeamsBridgeApp) : Promise<void> => {
-    
-    const dummyUsersToAdd : UserModel[] = [];
+    app: TeamsBridgeApp
+): Promise<void> => {
+    const dummyUsersToAdd: UserModel[] = [];
     for (const teamsUserId of teamsUserIdsToSave) {
-        const dummyUser = await retrieveDummyUserByTeamsUserIdAsync(read, teamsUserId);
+        const dummyUser = await retrieveDummyUserByTeamsUserIdAsync(
+            read,
+            teamsUserId
+        );
         if (dummyUser) {
             dummyUsersToAdd.push(dummyUser);
         }
@@ -461,20 +661,40 @@ export const handleAddTeamsUserContextualBarSubmitAsync = async (
 
     const roomRecord = await retrieveRoomByRocketChatRoomIdAsync(read, room.id);
     if (roomRecord && roomRecord.teamsThreadId) {
-        if (!roomRecord.bridgeUserRocketChatUserId ) {
-            await notifyNotLoggedInUserAsync(read, operator, room, app, AddUserLoginRequiredHintMessageText);
+        if (!roomRecord.bridgeUserRocketChatUserId) {
+            await notifyNotLoggedInUserAsync(
+                read,
+                operator,
+                room,
+                app,
+                AddUserLoginRequiredHintMessageText
+            );
             return;
         }
 
         // If there's a thread created in Teams side, need to update the participant there as well
-        const accessToken = await retrieveUserAccessTokenAsync(read, roomRecord.bridgeUserRocketChatUserId);
+        const accessToken = await retrieveUserAccessTokenAsync(
+            read,
+            roomRecord.bridgeUserRocketChatUserId
+        );
         if (!accessToken) {
-            await notifyNotLoggedInUserAsync(read, operator, room, app, AddUserLoginRequiredHintMessageText);
+            await notifyNotLoggedInUserAsync(
+                read,
+                operator,
+                room,
+                app,
+                AddUserLoginRequiredHintMessageText
+            );
             return;
         }
 
         for (const dummyUser of dummyUsersToAdd) {
-            await addMemberToChatThreadAsync(http, roomRecord.teamsThreadId, dummyUser.teamsUserId, accessToken);
+            await addMemberToChatThreadAsync(
+                http,
+                roomRecord.teamsThreadId,
+                dummyUser.teamsUserId,
+                accessToken
+            );
         }
     }
 
@@ -482,7 +702,9 @@ export const handleAddTeamsUserContextualBarSubmitAsync = async (
     const roomBuilder = await updater.room(room.id, operator);
 
     for (const dummyUser of dummyUsersToAdd) {
-        const userToAdd = await read.getUserReader().getById(dummyUser.rocketChatUserId);
+        const userToAdd = await read
+            .getUserReader()
+            .getById(dummyUser.rocketChatUserId);
         if (!userToAdd) {
             console.error("Dummy user to add not found!");
             continue;
@@ -499,7 +721,8 @@ export const handlePreRoomUserLeaveAsync = async (
     read: IRead,
     http: IHttp,
     persistence: IPersistence,
-    app: TeamsBridgeApp): Promise<void> => {
+    app: TeamsBridgeApp
+): Promise<void> => {
     const roomId = context.room.id;
 
     const roomRecord = await retrieveRoomByRocketChatRoomIdAsync(read, roomId);
@@ -508,40 +731,72 @@ export const handlePreRoomUserLeaveAsync = async (
     }
 
     const leavingRocketChatUserId = context.leavingUser.id;
-    const embeddedLoginUser = await retrieveUserByRocketChatUserIdAsync(read, leavingRocketChatUserId);
-    const dummyUser = await retrieveDummyUserByRocketChatUserIdAsync(read, leavingRocketChatUserId);
+    const embeddedLoginUser = await retrieveUserByRocketChatUserIdAsync(
+        read,
+        leavingRocketChatUserId
+    );
+    const dummyUser = await retrieveDummyUserByRocketChatUserIdAsync(
+        read,
+        leavingRocketChatUserId
+    );
 
     if (!embeddedLoginUser && !dummyUser) {
         console.error("Not logged in user or dummy user.");
         return;
     }
 
-    if (!roomRecord.bridgeUserRocketChatUserId ) {
+    if (!roomRecord.bridgeUserRocketChatUserId) {
         console.error("No bridge user.");
         throw new UserNotAllowedException();
     }
 
     // If there's a thread created in Teams side, need to update the participant there as well
-    const accessToken = await retrieveUserAccessTokenAsync(read, roomRecord.bridgeUserRocketChatUserId);
+    const accessToken = await retrieveUserAccessTokenAsync(
+        read,
+        roomRecord.bridgeUserRocketChatUserId
+    );
     if (!accessToken) {
         console.error("No bridge user.");
-        await persistRoomAsync(persistence, roomRecord.rocketChatRoomId, roomRecord.teamsThreadId, undefined);
+        await persistRoomAsync(
+            persistence,
+            roomRecord.rocketChatRoomId,
+            roomRecord.teamsThreadId,
+            undefined
+        );
         throw new UserNotAllowedException();
     }
 
-    const teamsUserId = embeddedLoginUser?.teamsUserId ?? dummyUser?.teamsUserId;
+    const teamsUserId =
+        embeddedLoginUser?.teamsUserId ?? dummyUser?.teamsUserId;
     if (!teamsUserId) {
         return;
     }
 
-    const threadMemberTeamsUserIds = await listMembersInChatThreadAsync(http, roomRecord.teamsThreadId, accessToken);
-    if (threadMemberTeamsUserIds.find(id => id === teamsUserId)) {
-        await removeMemberFromChatThreadAsync(http, roomRecord.teamsThreadId, teamsUserId, accessToken);
+    const threadMemberTeamsUserIds = await listMembersInChatThreadAsync(
+        http,
+        roomRecord.teamsThreadId,
+        accessToken
+    );
+    if (threadMemberTeamsUserIds.find((id) => id === teamsUserId)) {
+        await removeMemberFromChatThreadAsync(
+            http,
+            roomRecord.teamsThreadId,
+            teamsUserId,
+            accessToken
+        );
     }
 
-    if (embeddedLoginUser && embeddedLoginUser.teamsUserId === roomRecord.bridgeUserRocketChatUserId) {
+    if (
+        embeddedLoginUser &&
+        embeddedLoginUser.teamsUserId === roomRecord.bridgeUserRocketChatUserId
+    ) {
         // Clear bridge user if it's been removed
-        await persistRoomAsync(persistence, roomRecord.rocketChatRoomId, roomRecord.teamsThreadId, undefined);
+        await persistRoomAsync(
+            persistence,
+            roomRecord.rocketChatRoomId,
+            roomRecord.teamsThreadId,
+            undefined
+        );
     }
 };
 
@@ -551,20 +806,40 @@ export const handleUserRegistrationAutoRenewAsync = async (
     modify: IModify,
     http: IHttp,
     persis: IPersistence
-) : Promise<void> => {
-    const aadTenantId = (await read.getEnvironmentReader().getSettings().getById(AppSetting.AadTenantId)).value;
-    const aadClientId = (await read.getEnvironmentReader().getSettings().getById(AppSetting.AadClientId)).value;
-    const aadClientSecret = (await read.getEnvironmentReader().getSettings().getById(AppSetting.AadClientSecret)).value;
+): Promise<void> => {
+    const aadTenantId = (
+        await read
+            .getEnvironmentReader()
+            .getSettings()
+            .getById(AppSetting.AadTenantId)
+    ).value;
+    const aadClientId = (
+        await read
+            .getEnvironmentReader()
+            .getSettings()
+            .getById(AppSetting.AadClientId)
+    ).value;
+    const aadClientSecret = (
+        await read
+            .getEnvironmentReader()
+            .getSettings()
+            .getById(AppSetting.AadClientSecret)
+    ).value;
 
     const allRegistrations = await retrieveAllUserRegistrationsAsync(read);
-    
+
     if (allRegistrations) {
         for (const registration of allRegistrations) {
             try {
-                const refreshToken = await retrieveUserRefreshTokenAsync(read, registration.rocketChatUserId);
+                const refreshToken = await retrieveUserRefreshTokenAsync(
+                    read,
+                    registration.rocketChatUserId
+                );
 
                 if (!refreshToken) {
-                    throw new Error(`Refresh token for user ${registration.rocketChatUserId} not found!`);
+                    throw new Error(
+                        `Refresh token for user ${registration.rocketChatUserId} not found!`
+                    );
                 }
 
                 const response = await renewUserAccessTokenAsync(
@@ -572,7 +847,8 @@ export const handleUserRegistrationAutoRenewAsync = async (
                     refreshToken,
                     aadTenantId,
                     aadClientId,
-                    aadClientSecret);
+                    aadClientSecret
+                );
 
                 const userAccessToken = response.accessToken;
 
@@ -582,17 +858,30 @@ export const handleUserRegistrationAutoRenewAsync = async (
                     userAccessToken,
                     response.refreshToken as string,
                     response.expiresIn,
-                    response.extExpiresIn);
+                    response.extExpiresIn
+                );
 
-                const subscriptionIds = await listSubscriptionsAsync(http, userAccessToken);
+                const subscriptionIds = await listSubscriptionsAsync(
+                    http,
+                    userAccessToken
+                );
                 if (subscriptionIds) {
                     for (const subscriptionId of subscriptionIds) {
-                        await renewSubscriptionAsync(http, subscriptionId, userAccessToken);
+                        await renewSubscriptionAsync(
+                            http,
+                            subscriptionId,
+                            userAccessToken
+                        );
                     }
                 } else {
-                    const user = await retrieveUserByRocketChatUserIdAsync(read, registration.rocketChatUserId);
+                    const user = await retrieveUserByRocketChatUserIdAsync(
+                        read,
+                        registration.rocketChatUserId
+                    );
                     if (!user) {
-                        throw new Error(`User record for user ${registration.rocketChatUserId} not found!`);
+                        throw new Error(
+                            `User record for user ${registration.rocketChatUserId} not found!`
+                        );
                     }
 
                     await subscribeToAllMessagesForOneUserAsync(
@@ -600,21 +889,31 @@ export const handleUserRegistrationAutoRenewAsync = async (
                         user.rocketChatUserId,
                         user.teamsUserId,
                         subscriberEndpointUrl,
-                        userAccessToken);
+                        userAccessToken
+                    );
                 }
             } catch (error) {
-                console.error(`Error during renew registration for user ${registration.rocketChatUserId}. Ignore this error and continue. Error: ${error}`);
+                console.error(
+                    `Error during renew registration for user ${registration.rocketChatUserId}. Ignore this error and continue. Error: ${error}`
+                );
             }
         }
     }
 };
 
-const isTeamsMessageAsync = async (messageId: string | undefined, read: IRead) : Promise<boolean> => {
+const isTeamsMessageAsync = async (
+    messageId: string | undefined,
+    read: IRead
+): Promise<boolean> => {
     if (!messageId) {
         return false;
     }
 
-    const messageIdMapping = await retrieveMessageIdMappingByRocketChatMessageIdAsync(read, messageId);
+    const messageIdMapping =
+        await retrieveMessageIdMappingByRocketChatMessageIdAsync(
+            read,
+            messageId
+        );
     if (messageIdMapping) {
         return true;
     }
@@ -622,11 +921,17 @@ const isTeamsMessageAsync = async (messageId: string | undefined, read: IRead) :
     return false;
 };
 
-const findOneTeamsLoggedInUsersAsync = async (read: IRead, users: IUser[]) : Promise<UserModel | null> => {
+const findOneTeamsLoggedInUsersAsync = async (
+    read: IRead,
+    users: IUser[]
+): Promise<UserModel | null> => {
     for (const user of users) {
         const accessToken = await retrieveUserAccessTokenAsync(read, user.id);
         if (accessToken) {
-            const userModel = await retrieveUserByRocketChatUserIdAsync(read, user.id);
+            const userModel = await retrieveUserByRocketChatUserIdAsync(
+                read,
+                user.id
+            );
             return userModel;
         }
     }
@@ -639,15 +944,39 @@ const notifyNotLoggedInUserAsync = async (
     user: IUser,
     room: IRoom,
     app: TeamsBridgeApp,
-    hintMessageText: string) : Promise<void> => {
+    hintMessageText: string
+): Promise<void> => {
     const appUser = (await read.getUserReader().getAppUser()) as IUser;
 
-    const aadTenantId = (await read.getEnvironmentReader().getSettings().getById(AppSetting.AadTenantId)).value;
-    const aadClientId = (await read.getEnvironmentReader().getSettings().getById(AppSetting.AadClientId)).value;
+    const aadTenantId = (
+        await read
+            .getEnvironmentReader()
+            .getSettings()
+            .getById(AppSetting.AadTenantId)
+    ).value;
+    const aadClientId = (
+        await read
+            .getEnvironmentReader()
+            .getSettings()
+            .getById(AppSetting.AadClientId)
+    ).value;
     const accessors = app.getAccessors();
-    const authEndpointUrl = await getRocketChatAppEndpointUrl(accessors, AuthenticationEndpointPath);
-    const loginUrl = getLoginUrl(aadTenantId, aadClientId, authEndpointUrl, user.id);
-    const message = generateHintMessageWithTeamsLoginButton(loginUrl, appUser, room, hintMessageText)
-    
+    const authEndpointUrl = await getRocketChatAppEndpointUrl(
+        accessors,
+        AuthenticationEndpointPath
+    );
+    const loginUrl = getLoginUrl(
+        aadTenantId,
+        aadClientId,
+        authEndpointUrl,
+        user.id
+    );
+    const message = generateHintMessageWithTeamsLoginButton(
+        loginUrl,
+        appUser,
+        room,
+        hintMessageText
+    );
+
     await notifyRocketChatUserAsync(message, user, read.getNotifier());
 };

--- a/lib/PersistHelper.ts
+++ b/lib/PersistHelper.ts
@@ -1,5 +1,12 @@
-import { IPersistence, IPersistenceRead, IRead } from "@rocket.chat/apps-engine/definition/accessors";
-import { RocketChatAssociationModel, RocketChatAssociationRecord } from "@rocket.chat/apps-engine/definition/metadata";
+import {
+    IPersistence,
+    IPersistenceRead,
+    IRead,
+} from '@rocket.chat/apps-engine/definition/accessors';
+import {
+    RocketChatAssociationModel,
+    RocketChatAssociationRecord,
+} from '@rocket.chat/apps-engine/definition/metadata';
 
 const MiscKeys = {
     ApplicationAccessToken: 'ApplicationAccessToken',
@@ -11,42 +18,43 @@ const MiscKeys = {
     Room: 'Room',
     TeamsUserProfile: 'TeamsUserProfile',
     OneDriveFile: 'OneDriveFile',
+    LoginMessage: 'LoginMessage',
 };
 
 interface ApplicationAccessTokenModel {
-    accessToken: string,
-};
+    accessToken: string;
+}
 
 interface UserRegistrationModel {
-    rocketChatUserId: string,
-    accessToken: string,
-    refreshToken: string,
-    expires: number,
-    extExpires: number,
-};
+    rocketChatUserId: string;
+    accessToken: string;
+    refreshToken: string;
+    expires: number;
+    extExpires: number;
+}
 
 export interface UserModel {
-    rocketChatUserId: string,
-    teamsUserId: string,
-};
+    rocketChatUserId: string;
+    teamsUserId: string;
+}
 
 export interface SubscriptionModel {
-    rocketChatUserId: string,
-    subscriptionId: string,
-    expires: number,
-};
+    rocketChatUserId: string;
+    subscriptionId: string;
+    expires: number;
+}
 
 export interface MessageIdModel {
-    rocketChatMessageId: string,
-    teamsMessageId: string,
-    teamsThreadId: string,
-};
+    rocketChatMessageId: string;
+    teamsMessageId: string;
+    teamsThreadId: string;
+}
 
 export interface RoomModel {
-    rocketChatRoomId: string,
-    teamsThreadId?: string,
-    bridgeUserRocketChatUserId?: string,
-};
+    rocketChatRoomId: string;
+    teamsThreadId?: string;
+    bridgeUserRocketChatUserId?: string;
+}
 
 export interface TeamsUserProfileModel {
     displayName: string;
@@ -54,21 +62,25 @@ export interface TeamsUserProfileModel {
     surname: string;
     mail: string;
     teamsUserId: string;
-};
+}
 
 export interface OneDriveFileModel {
     fileName: string;
     driveItemId: string;
-};
+}
 
 export const persistApplicationAccessTokenAsync = async (
     persis: IPersistence,
-    accessToken: string) : Promise<void> => {
+    accessToken: string
+): Promise<void> => {
     const associations: Array<RocketChatAssociationRecord> = [
-        new RocketChatAssociationRecord(RocketChatAssociationModel.MISC, MiscKeys.ApplicationAccessToken),
+        new RocketChatAssociationRecord(
+            RocketChatAssociationModel.MISC,
+            MiscKeys.ApplicationAccessToken
+        ),
     ];
-    const data : ApplicationAccessTokenModel = {
-        accessToken: accessToken,
+    const data: ApplicationAccessTokenModel = {
+        accessToken,
     };
 
     await persis.updateByAssociations(associations, data, true);
@@ -80,19 +92,26 @@ export const persistUserAccessTokenAsync = async (
     accessToken: string,
     refreshToken: string,
     expiresIn: number,
-    extExpiresIn: number) : Promise<void> => {
+    extExpiresIn: number
+): Promise<void> => {
     const associations: Array<RocketChatAssociationRecord> = [
-        new RocketChatAssociationRecord(RocketChatAssociationModel.MISC, MiscKeys.UserRegistration),
-        new RocketChatAssociationRecord(RocketChatAssociationModel.USER, rocketChatUserId),
+        new RocketChatAssociationRecord(
+            RocketChatAssociationModel.MISC,
+            MiscKeys.UserRegistration
+        ),
+        new RocketChatAssociationRecord(
+            RocketChatAssociationModel.USER,
+            rocketChatUserId
+        ),
     ];
 
     const now = new Date();
     const epochInSecond = Math.round(now.getTime() / 1000);
 
-    const data : UserRegistrationModel = {
-        rocketChatUserId: rocketChatUserId,
-        accessToken: accessToken,
-        refreshToken: refreshToken,
+    const data: UserRegistrationModel = {
+        rocketChatUserId,
+        accessToken,
+        refreshToken,
         expires: epochInSecond + expiresIn,
         extExpires: epochInSecond + extExpiresIn,
     };
@@ -103,43 +122,77 @@ export const persistUserAccessTokenAsync = async (
 export const persistDummyUserAsync = async (
     persis: IPersistence,
     rocketChatUserId: string,
-    teamsUserId: string) : Promise<void> => {
+    teamsUserId: string
+): Promise<void> => {
     const associationsByRocketChatUserId: Array<RocketChatAssociationRecord> = [
-        new RocketChatAssociationRecord(RocketChatAssociationModel.MISC, MiscKeys.DummyUser),
-        new RocketChatAssociationRecord(RocketChatAssociationModel.USER, rocketChatUserId),
+        new RocketChatAssociationRecord(
+            RocketChatAssociationModel.MISC,
+            MiscKeys.DummyUser
+        ),
+        new RocketChatAssociationRecord(
+            RocketChatAssociationModel.USER,
+            rocketChatUserId
+        ),
     ];
     const associationsByTeamsUserId: Array<RocketChatAssociationRecord> = [
-        new RocketChatAssociationRecord(RocketChatAssociationModel.MISC, MiscKeys.DummyUser),
-        new RocketChatAssociationRecord(RocketChatAssociationModel.USER, teamsUserId),
+        new RocketChatAssociationRecord(
+            RocketChatAssociationModel.MISC,
+            MiscKeys.DummyUser
+        ),
+        new RocketChatAssociationRecord(
+            RocketChatAssociationModel.USER,
+            teamsUserId
+        ),
     ];
 
-    const data : UserModel = {
-        rocketChatUserId: rocketChatUserId,
-        teamsUserId: teamsUserId,
+    const data: UserModel = {
+        rocketChatUserId,
+        teamsUserId,
     };
 
-    await persis.updateByAssociations(associationsByRocketChatUserId, data, true);
+    await persis.updateByAssociations(
+        associationsByRocketChatUserId,
+        data,
+        true
+    );
     await persis.updateByAssociations(associationsByTeamsUserId, data, true);
 };
 
 export const persistUserAsync = async (
     persis: IPersistence,
     rocketChatUserId: string,
-    teamsUserId: string) : Promise<void> => {
+    teamsUserId: string
+): Promise<void> => {
     const associationsByRocketChatUserId: Array<RocketChatAssociationRecord> = [
-        new RocketChatAssociationRecord(RocketChatAssociationModel.MISC, MiscKeys.User),
-        new RocketChatAssociationRecord(RocketChatAssociationModel.USER, rocketChatUserId),
+        new RocketChatAssociationRecord(
+            RocketChatAssociationModel.MISC,
+            MiscKeys.User
+        ),
+        new RocketChatAssociationRecord(
+            RocketChatAssociationModel.USER,
+            rocketChatUserId
+        ),
     ];
     const associationsByTeamsUserId: Array<RocketChatAssociationRecord> = [
-        new RocketChatAssociationRecord(RocketChatAssociationModel.MISC, MiscKeys.User),
-        new RocketChatAssociationRecord(RocketChatAssociationModel.USER, teamsUserId),
+        new RocketChatAssociationRecord(
+            RocketChatAssociationModel.MISC,
+            MiscKeys.User
+        ),
+        new RocketChatAssociationRecord(
+            RocketChatAssociationModel.USER,
+            teamsUserId
+        ),
     ];
-    const data : UserModel = {
-        rocketChatUserId: rocketChatUserId,
-        teamsUserId: teamsUserId,
+    const data: UserModel = {
+        rocketChatUserId,
+        teamsUserId,
     };
 
-    await persis.updateByAssociations(associationsByRocketChatUserId, data, true);
+    await persis.updateByAssociations(
+        associationsByRocketChatUserId,
+        data,
+        true
+    );
     await persis.updateByAssociations(associationsByTeamsUserId, data, true);
 };
 
@@ -147,14 +200,21 @@ export const persistSubscriptionAsync = async (
     persis: IPersistence,
     rocketChatUserId: string,
     subscriptionId: string,
-    expirationTime: Date) : Promise<void> => {
+    expirationTime: Date
+): Promise<void> => {
     const associations: Array<RocketChatAssociationRecord> = [
-        new RocketChatAssociationRecord(RocketChatAssociationModel.MISC, MiscKeys.Subscription),
-        new RocketChatAssociationRecord(RocketChatAssociationModel.USER, rocketChatUserId),
+        new RocketChatAssociationRecord(
+            RocketChatAssociationModel.MISC,
+            MiscKeys.Subscription
+        ),
+        new RocketChatAssociationRecord(
+            RocketChatAssociationModel.USER,
+            rocketChatUserId
+        ),
     ];
-    const data : SubscriptionModel = {
-        rocketChatUserId: rocketChatUserId,
-        subscriptionId: subscriptionId,
+    const data: SubscriptionModel = {
+        rocketChatUserId,
+        subscriptionId,
         expires: Math.round(expirationTime.getTime() / 1000),
     };
 
@@ -165,22 +225,40 @@ export const persistMessageIdMappingAsync = async (
     persis: IPersistence,
     rocketChatMessageId: string,
     teamsMessageId: string,
-    teamsThreadId: string) : Promise<void> => {
-    const associationsByRocketChatMessageId: Array<RocketChatAssociationRecord> = [
-        new RocketChatAssociationRecord(RocketChatAssociationModel.MISC, MiscKeys.MessageIdMapping),
-        new RocketChatAssociationRecord(RocketChatAssociationModel.MESSAGE, rocketChatMessageId),
-    ];
+    teamsThreadId: string
+): Promise<void> => {
+    const associationsByRocketChatMessageId: Array<RocketChatAssociationRecord> =
+        [
+            new RocketChatAssociationRecord(
+                RocketChatAssociationModel.MISC,
+                MiscKeys.MessageIdMapping
+            ),
+            new RocketChatAssociationRecord(
+                RocketChatAssociationModel.MESSAGE,
+                rocketChatMessageId
+            ),
+        ];
     const associationsByTeamsMessageId: Array<RocketChatAssociationRecord> = [
-        new RocketChatAssociationRecord(RocketChatAssociationModel.MISC, MiscKeys.MessageIdMapping),
-        new RocketChatAssociationRecord(RocketChatAssociationModel.MESSAGE, teamsMessageId),
+        new RocketChatAssociationRecord(
+            RocketChatAssociationModel.MISC,
+            MiscKeys.MessageIdMapping
+        ),
+        new RocketChatAssociationRecord(
+            RocketChatAssociationModel.MESSAGE,
+            teamsMessageId
+        ),
     ];
-    const data : MessageIdModel = {
-        rocketChatMessageId: rocketChatMessageId,
-        teamsMessageId: teamsMessageId,
-        teamsThreadId: teamsThreadId,
+    const data: MessageIdModel = {
+        rocketChatMessageId,
+        teamsMessageId,
+        teamsThreadId,
     };
 
-    await persis.updateByAssociations(associationsByRocketChatMessageId, data, true);
+    await persis.updateByAssociations(
+        associationsByRocketChatMessageId,
+        data,
+        true
+    );
     await persis.updateByAssociations(associationsByTeamsMessageId, data, true);
 };
 
@@ -188,27 +266,49 @@ export const persistRoomAsync = async (
     persis: IPersistence,
     rocketChatRoomId: string,
     teamsThreadId?: string,
-    bridgeUserRocketChatUserId?: string) : Promise<void> => {
+    bridgeUserRocketChatUserId?: string
+): Promise<void> => {
     const associationsByRocketChatRoomId: Array<RocketChatAssociationRecord> = [
-        new RocketChatAssociationRecord(RocketChatAssociationModel.MISC, MiscKeys.Room),
-        new RocketChatAssociationRecord(RocketChatAssociationModel.MESSAGE, rocketChatRoomId),
+        new RocketChatAssociationRecord(
+            RocketChatAssociationModel.MISC,
+            MiscKeys.Room
+        ),
+        new RocketChatAssociationRecord(
+            RocketChatAssociationModel.MESSAGE,
+            rocketChatRoomId
+        ),
     ];
 
-    const data : RoomModel = {
-        rocketChatRoomId: rocketChatRoomId,
-        teamsThreadId: teamsThreadId,
-        bridgeUserRocketChatUserId: bridgeUserRocketChatUserId,
+    const data: RoomModel = {
+        rocketChatRoomId,
+        teamsThreadId,
+        bridgeUserRocketChatUserId,
     };
 
-    await persis.updateByAssociations(associationsByRocketChatRoomId, data, true);
+    await persis.updateByAssociations(
+        associationsByRocketChatRoomId,
+        data,
+        true
+    );
 
     if (teamsThreadId) {
-        const associationsByTeamsThreadId: Array<RocketChatAssociationRecord> = [
-            new RocketChatAssociationRecord(RocketChatAssociationModel.MISC, MiscKeys.Room),
-            new RocketChatAssociationRecord(RocketChatAssociationModel.MESSAGE, teamsThreadId),
-        ];
-    
-        await persis.updateByAssociations(associationsByTeamsThreadId, data, true);
+        const associationsByTeamsThreadId: Array<RocketChatAssociationRecord> =
+            [
+                new RocketChatAssociationRecord(
+                    RocketChatAssociationModel.MISC,
+                    MiscKeys.Room
+                ),
+                new RocketChatAssociationRecord(
+                    RocketChatAssociationModel.MESSAGE,
+                    teamsThreadId
+                ),
+            ];
+
+        await persis.updateByAssociations(
+            associationsByTeamsThreadId,
+            data,
+            true
+        );
     }
 };
 
@@ -218,19 +318,25 @@ export const persistTeamsUserProfileAsync = async (
     givenName: string,
     surname: string,
     mail: string,
-    teamsUserId: string) : Promise<void> => {
-    
+    teamsUserId: string
+): Promise<void> => {
     const associations: Array<RocketChatAssociationRecord> = [
-        new RocketChatAssociationRecord(RocketChatAssociationModel.MISC, MiscKeys.TeamsUserProfile),
-        new RocketChatAssociationRecord(RocketChatAssociationModel.USER, teamsUserId),
+        new RocketChatAssociationRecord(
+            RocketChatAssociationModel.MISC,
+            MiscKeys.TeamsUserProfile
+        ),
+        new RocketChatAssociationRecord(
+            RocketChatAssociationModel.USER,
+            teamsUserId
+        ),
     ];
 
-    const data : TeamsUserProfileModel = {
-        displayName: displayName,
-        givenName: givenName,
-        surname: surname,
-        mail: mail,
-        teamsUserId: teamsUserId,
+    const data: TeamsUserProfileModel = {
+        displayName,
+        givenName,
+        surname,
+        mail,
+        teamsUserId,
     };
 
     await persis.updateByAssociations(associations, data, true);
@@ -239,24 +345,36 @@ export const persistTeamsUserProfileAsync = async (
 export const persistOneDriveFileAsync = async (
     persis: IPersistence,
     fileName: string,
-    driveItemId: string,
-) : Promise<void> => {
+    driveItemId: string
+): Promise<void> => {
     const associations: Array<RocketChatAssociationRecord> = [
-        new RocketChatAssociationRecord(RocketChatAssociationModel.MISC, MiscKeys.OneDriveFile),
-        new RocketChatAssociationRecord(RocketChatAssociationModel.FILE, fileName),
+        new RocketChatAssociationRecord(
+            RocketChatAssociationModel.MISC,
+            MiscKeys.OneDriveFile
+        ),
+        new RocketChatAssociationRecord(
+            RocketChatAssociationModel.FILE,
+            fileName
+        ),
     ];
 
-    const data : OneDriveFileModel = {
-        fileName: fileName,
-        driveItemId: driveItemId,
+    const data: OneDriveFileModel = {
+        fileName,
+        driveItemId,
     };
 
     await persis.updateByAssociations(associations, data, true);
 };
 
-export const checkDummyUserByRocketChatUserIdAsync = async (read: IRead, rocketChatUserId: string) : Promise<boolean> => {
-    const data = await retrieveDummyUserByRocketChatUserIdAsync(read, rocketChatUserId);
-    
+export const checkDummyUserByRocketChatUserIdAsync = async (
+    read: IRead,
+    rocketChatUserId: string
+): Promise<boolean> => {
+    const data = await retrieveDummyUserByRocketChatUserIdAsync(
+        read,
+        rocketChatUserId
+    );
+
     if (data === undefined || data === null) {
         return false;
     }
@@ -264,13 +382,22 @@ export const checkDummyUserByRocketChatUserIdAsync = async (read: IRead, rocketC
     return true;
 };
 
-export const retrieveDummyUserByRocketChatUserIdAsync = async (read: IRead, rocketChatUserId: string) : Promise<UserModel | null> => {
+export const retrieveDummyUserByRocketChatUserIdAsync = async (
+    read: IRead,
+    rocketChatUserId: string
+): Promise<UserModel | null> => {
     const associations: Array<RocketChatAssociationRecord> = [
-        new RocketChatAssociationRecord(RocketChatAssociationModel.MISC, MiscKeys.DummyUser),
-        new RocketChatAssociationRecord(RocketChatAssociationModel.USER, rocketChatUserId),
+        new RocketChatAssociationRecord(
+            RocketChatAssociationModel.MISC,
+            MiscKeys.DummyUser
+        ),
+        new RocketChatAssociationRecord(
+            RocketChatAssociationModel.USER,
+            rocketChatUserId
+        ),
     ];
 
-    const persistenceRead : IPersistenceRead = read.getPersistenceReader();
+    const persistenceRead: IPersistenceRead = read.getPersistenceReader();
     const results = await persistenceRead.readByAssociations(associations);
 
     if (results === undefined || results === null || results.length == 0) {
@@ -278,20 +405,31 @@ export const retrieveDummyUserByRocketChatUserIdAsync = async (read: IRead, rock
     }
 
     if (results.length > 1) {
-        throw new Error(`More than one DummyUser record for Rocket.Chat user ${rocketChatUserId}`);
+        throw new Error(
+            `More than one DummyUser record for Rocket.Chat user ${rocketChatUserId}`
+        );
     }
 
-    const data : UserModel = results[0] as UserModel;
+    const data: UserModel = results[0] as UserModel;
     return data;
 };
 
-export const retrieveDummyUserByTeamsUserIdAsync = async (read: IRead, teamsUserId: string) : Promise<UserModel | null> => {
+export const retrieveDummyUserByTeamsUserIdAsync = async (
+    read: IRead,
+    teamsUserId: string
+): Promise<UserModel | null> => {
     const associations: Array<RocketChatAssociationRecord> = [
-        new RocketChatAssociationRecord(RocketChatAssociationModel.MISC, MiscKeys.DummyUser),
-        new RocketChatAssociationRecord(RocketChatAssociationModel.USER, teamsUserId),
+        new RocketChatAssociationRecord(
+            RocketChatAssociationModel.MISC,
+            MiscKeys.DummyUser
+        ),
+        new RocketChatAssociationRecord(
+            RocketChatAssociationModel.USER,
+            teamsUserId
+        ),
     ];
 
-    const persistenceRead : IPersistenceRead = read.getPersistenceReader();
+    const persistenceRead: IPersistenceRead = read.getPersistenceReader();
     const results = await persistenceRead.readByAssociations(associations);
 
     if (results === undefined || results === null || results.length == 0) {
@@ -299,20 +437,31 @@ export const retrieveDummyUserByTeamsUserIdAsync = async (read: IRead, teamsUser
     }
 
     if (results.length > 1) {
-        throw new Error(`More than one DummyUser record for Teams user ${teamsUserId}`);
+        throw new Error(
+            `More than one DummyUser record for Teams user ${teamsUserId}`
+        );
     }
 
-    const data : UserModel = results[0] as UserModel;
+    const data: UserModel = results[0] as UserModel;
     return data;
 };
 
-export const retrieveUserByRocketChatUserIdAsync = async (read: IRead, rocketChatUserId: string) : Promise<UserModel | null> => {
+export const retrieveUserByRocketChatUserIdAsync = async (
+    read: IRead,
+    rocketChatUserId: string
+): Promise<UserModel | null> => {
     const associations: Array<RocketChatAssociationRecord> = [
-        new RocketChatAssociationRecord(RocketChatAssociationModel.MISC, MiscKeys.User),
-        new RocketChatAssociationRecord(RocketChatAssociationModel.USER, rocketChatUserId),
+        new RocketChatAssociationRecord(
+            RocketChatAssociationModel.MISC,
+            MiscKeys.User
+        ),
+        new RocketChatAssociationRecord(
+            RocketChatAssociationModel.USER,
+            rocketChatUserId
+        ),
     ];
 
-    const persistenceRead : IPersistenceRead = read.getPersistenceReader();
+    const persistenceRead: IPersistenceRead = read.getPersistenceReader();
     const results = await persistenceRead.readByAssociations(associations);
 
     if (results === undefined || results === null || results.length == 0) {
@@ -320,20 +469,31 @@ export const retrieveUserByRocketChatUserIdAsync = async (read: IRead, rocketCha
     }
 
     if (results.length > 1) {
-        throw new Error(`More than one User record for user ${rocketChatUserId}`);
+        throw new Error(
+            `More than one User record for user ${rocketChatUserId}`
+        );
     }
 
-    const data : UserModel = results[0] as UserModel;
+    const data: UserModel = results[0] as UserModel;
     return data;
 };
 
-export const retrieveUserByTeamsUserIdAsync = async (read: IRead, teamsUserId: string) : Promise<UserModel | null> => {
+export const retrieveUserByTeamsUserIdAsync = async (
+    read: IRead,
+    teamsUserId: string
+): Promise<UserModel | null> => {
     const associations: Array<RocketChatAssociationRecord> = [
-        new RocketChatAssociationRecord(RocketChatAssociationModel.MISC, MiscKeys.User),
-        new RocketChatAssociationRecord(RocketChatAssociationModel.USER, teamsUserId),
+        new RocketChatAssociationRecord(
+            RocketChatAssociationModel.MISC,
+            MiscKeys.User
+        ),
+        new RocketChatAssociationRecord(
+            RocketChatAssociationModel.USER,
+            teamsUserId
+        ),
     ];
 
-    const persistenceRead : IPersistenceRead = read.getPersistenceReader();
+    const persistenceRead: IPersistenceRead = read.getPersistenceReader();
     const results = await persistenceRead.readByAssociations(associations);
 
     if (results === undefined || results === null || results.length == 0) {
@@ -344,17 +504,26 @@ export const retrieveUserByTeamsUserIdAsync = async (read: IRead, teamsUserId: s
         throw new Error(`More than one User record for user ${teamsUserId}`);
     }
 
-    const data : UserModel = results[0] as UserModel;
+    const data: UserModel = results[0] as UserModel;
     return data;
 };
 
-export const retrieveUserAccessTokenAsync = async (read: IRead, rocketChatUserId: string) : Promise<string | null> => {
+export const retrieveUserAccessTokenAsync = async (
+    read: IRead,
+    rocketChatUserId: string
+): Promise<string | null> => {
     const associations: Array<RocketChatAssociationRecord> = [
-        new RocketChatAssociationRecord(RocketChatAssociationModel.MISC, MiscKeys.UserRegistration),
-        new RocketChatAssociationRecord(RocketChatAssociationModel.USER, rocketChatUserId),
+        new RocketChatAssociationRecord(
+            RocketChatAssociationModel.MISC,
+            MiscKeys.UserRegistration
+        ),
+        new RocketChatAssociationRecord(
+            RocketChatAssociationModel.USER,
+            rocketChatUserId
+        ),
     ];
 
-    const persistenceRead : IPersistenceRead = read.getPersistenceReader();
+    const persistenceRead: IPersistenceRead = read.getPersistenceReader();
     const results = await persistenceRead.readByAssociations(associations);
 
     if (results === undefined || results === null || results.length == 0) {
@@ -362,10 +531,12 @@ export const retrieveUserAccessTokenAsync = async (read: IRead, rocketChatUserId
     }
 
     if (results.length > 1) {
-        throw new Error(`More than one UserAccessToken record for user ${rocketChatUserId}`);
+        throw new Error(
+            `More than one UserAccessToken record for user ${rocketChatUserId}`
+        );
     }
 
-    const data : UserRegistrationModel = results[0] as UserRegistrationModel;
+    const data: UserRegistrationModel = results[0] as UserRegistrationModel;
 
     const now = new Date();
     const epochInSecond = Math.round(now.getTime() / 1000);
@@ -377,13 +548,22 @@ export const retrieveUserAccessTokenAsync = async (read: IRead, rocketChatUserId
     return data.accessToken;
 };
 
-export const retrieveUserRefreshTokenAsync = async (read: IRead, rocketChatUserId: string) : Promise<string | null> => {
+export const retrieveUserRefreshTokenAsync = async (
+    read: IRead,
+    rocketChatUserId: string
+): Promise<string | null> => {
     const associations: Array<RocketChatAssociationRecord> = [
-        new RocketChatAssociationRecord(RocketChatAssociationModel.MISC, MiscKeys.UserRegistration),
-        new RocketChatAssociationRecord(RocketChatAssociationModel.USER, rocketChatUserId),
+        new RocketChatAssociationRecord(
+            RocketChatAssociationModel.MISC,
+            MiscKeys.UserRegistration
+        ),
+        new RocketChatAssociationRecord(
+            RocketChatAssociationModel.USER,
+            rocketChatUserId
+        ),
     ];
 
-    const persistenceRead : IPersistenceRead = read.getPersistenceReader();
+    const persistenceRead: IPersistenceRead = read.getPersistenceReader();
     const results = await persistenceRead.readByAssociations(associations);
 
     if (results === undefined || results === null || results.length == 0) {
@@ -391,10 +571,12 @@ export const retrieveUserRefreshTokenAsync = async (read: IRead, rocketChatUserI
     }
 
     if (results.length > 1) {
-        throw new Error(`More than one UserAccessToken record for user ${rocketChatUserId}`);
+        throw new Error(
+            `More than one UserAccessToken record for user ${rocketChatUserId}`
+        );
     }
 
-    const data : UserRegistrationModel = results[0] as UserRegistrationModel;
+    const data: UserRegistrationModel = results[0] as UserRegistrationModel;
 
     const now = new Date();
     const epochInSecond = Math.round(now.getTime() / 1000);
@@ -406,26 +588,33 @@ export const retrieveUserRefreshTokenAsync = async (read: IRead, rocketChatUserI
     return data.refreshToken;
 };
 
-export const retrieveAllUserRegistrationsAsync = async (read: IRead) : Promise<UserRegistrationModel[] | null> => {
-    
+export const retrieveAllUserRegistrationsAsync = async (
+    read: IRead
+): Promise<Array<UserRegistrationModel> | null> => {
     const associations: Array<RocketChatAssociationRecord> = [
-        new RocketChatAssociationRecord(RocketChatAssociationModel.MISC, MiscKeys.UserRegistration),
+        new RocketChatAssociationRecord(
+            RocketChatAssociationModel.MISC,
+            MiscKeys.UserRegistration
+        ),
     ];
-    
-    const persistenceRead : IPersistenceRead = read.getPersistenceReader();
+
+    const persistenceRead: IPersistenceRead = read.getPersistenceReader();
     const results = await persistenceRead.readByAssociations(associations);
 
     if (results === undefined || results === null || results.length == 0) {
         return null;
     }
 
-    const data : UserRegistrationModel[] = [];
+    const data: Array<UserRegistrationModel> = [];
 
     const now = new Date();
     const epochInSecond = Math.round(now.getTime() / 1000);
     for (const result of results) {
         const registration = result as UserRegistrationModel;
-        if (!registration.extExpires || epochInSecond > registration.extExpires) {
+        if (
+            !registration.extExpires ||
+            epochInSecond > registration.extExpires
+        ) {
             continue;
         }
         data.push(registration);
@@ -434,13 +623,22 @@ export const retrieveAllUserRegistrationsAsync = async (read: IRead) : Promise<U
     return data;
 };
 
-export const retrieveSubscriptionAsync = async (read: IRead, rocketChatUserId: string) : Promise<SubscriptionModel | null> => {
+export const retrieveSubscriptionAsync = async (
+    read: IRead,
+    rocketChatUserId: string
+): Promise<SubscriptionModel | null> => {
     const associations: Array<RocketChatAssociationRecord> = [
-        new RocketChatAssociationRecord(RocketChatAssociationModel.MISC, MiscKeys.Subscription),
-        new RocketChatAssociationRecord(RocketChatAssociationModel.USER, rocketChatUserId),
+        new RocketChatAssociationRecord(
+            RocketChatAssociationModel.MISC,
+            MiscKeys.Subscription
+        ),
+        new RocketChatAssociationRecord(
+            RocketChatAssociationModel.USER,
+            rocketChatUserId
+        ),
     ];
 
-    const persistenceRead : IPersistenceRead = read.getPersistenceReader();
+    const persistenceRead: IPersistenceRead = read.getPersistenceReader();
     const results = await persistenceRead.readByAssociations(associations);
 
     if (results === undefined || results === null || results.length == 0) {
@@ -448,10 +646,12 @@ export const retrieveSubscriptionAsync = async (read: IRead, rocketChatUserId: s
     }
 
     if (results.length > 1) {
-        throw new Error(`More than one Subscription record for user ${rocketChatUserId}`);
+        throw new Error(
+            `More than one Subscription record for user ${rocketChatUserId}`
+        );
     }
 
-    const data : SubscriptionModel = results[0] as SubscriptionModel;
+    const data: SubscriptionModel = results[0] as SubscriptionModel;
 
     const now = new Date();
     const epochInSecond = Math.round(now.getTime() / 1000);
@@ -465,125 +665,182 @@ export const retrieveSubscriptionAsync = async (read: IRead, rocketChatUserId: s
 
 export const retrieveMessageIdMappingByRocketChatMessageIdAsync = async (
     read: IRead,
-    rocketChatMessageId: string) : Promise<MessageIdModel | null> => {
-    const associationsByRocketChatMessageId: Array<RocketChatAssociationRecord> = [
-        new RocketChatAssociationRecord(RocketChatAssociationModel.MISC, MiscKeys.MessageIdMapping),
-        new RocketChatAssociationRecord(RocketChatAssociationModel.MESSAGE, rocketChatMessageId),
-    ];
+    rocketChatMessageId: string
+): Promise<MessageIdModel | null> => {
+    const associationsByRocketChatMessageId: Array<RocketChatAssociationRecord> =
+        [
+            new RocketChatAssociationRecord(
+                RocketChatAssociationModel.MISC,
+                MiscKeys.MessageIdMapping
+            ),
+            new RocketChatAssociationRecord(
+                RocketChatAssociationModel.MESSAGE,
+                rocketChatMessageId
+            ),
+        ];
 
-    const persistenceRead : IPersistenceRead = read.getPersistenceReader();
-    const results = await persistenceRead.readByAssociations(associationsByRocketChatMessageId);
+    const persistenceRead: IPersistenceRead = read.getPersistenceReader();
+    const results = await persistenceRead.readByAssociations(
+        associationsByRocketChatMessageId
+    );
 
     if (results === undefined || results === null || results.length == 0) {
         return null;
     }
 
     if (results.length > 1) {
-        throw new Error(`More than one ID mapping record for message ${rocketChatMessageId}`);
+        throw new Error(
+            `More than one ID mapping record for message ${rocketChatMessageId}`
+        );
     }
 
-    const data : MessageIdModel = results[0] as MessageIdModel;
+    const data: MessageIdModel = results[0] as MessageIdModel;
 
     return data;
 };
 
 export const retrieveMessageIdMappingByTeamsMessageIdAsync = async (
     read: IRead,
-    teamsMessageId: string) : Promise<MessageIdModel | null> => {
+    teamsMessageId: string
+): Promise<MessageIdModel | null> => {
     const associationsByTeamsMessageId: Array<RocketChatAssociationRecord> = [
-        new RocketChatAssociationRecord(RocketChatAssociationModel.MISC, MiscKeys.MessageIdMapping),
-        new RocketChatAssociationRecord(RocketChatAssociationModel.MESSAGE, teamsMessageId),
+        new RocketChatAssociationRecord(
+            RocketChatAssociationModel.MISC,
+            MiscKeys.MessageIdMapping
+        ),
+        new RocketChatAssociationRecord(
+            RocketChatAssociationModel.MESSAGE,
+            teamsMessageId
+        ),
     ];
 
-    const persistenceRead : IPersistenceRead = read.getPersistenceReader();
-    const results = await persistenceRead.readByAssociations(associationsByTeamsMessageId);
+    const persistenceRead: IPersistenceRead = read.getPersistenceReader();
+    const results = await persistenceRead.readByAssociations(
+        associationsByTeamsMessageId
+    );
 
     if (results === undefined || results === null || results.length == 0) {
         return null;
     }
 
     if (results.length > 1) {
-        throw new Error(`More than one ID mapping record for message ${teamsMessageId}`);
+        throw new Error(
+            `More than one ID mapping record for message ${teamsMessageId}`
+        );
     }
 
-    const data : MessageIdModel = results[0] as MessageIdModel;
+    const data: MessageIdModel = results[0] as MessageIdModel;
 
     return data;
 };
 
 export const retrieveRoomByRocketChatRoomIdAsync = async (
     read: IRead,
-    rocketChatRoomId: string) : Promise<RoomModel | null> => {
+    rocketChatRoomId: string
+): Promise<RoomModel | null> => {
     const associationsByRocketChatRoomId: Array<RocketChatAssociationRecord> = [
-        new RocketChatAssociationRecord(RocketChatAssociationModel.MISC, MiscKeys.Room),
-        new RocketChatAssociationRecord(RocketChatAssociationModel.MESSAGE, rocketChatRoomId),
+        new RocketChatAssociationRecord(
+            RocketChatAssociationModel.MISC,
+            MiscKeys.Room
+        ),
+        new RocketChatAssociationRecord(
+            RocketChatAssociationModel.MESSAGE,
+            rocketChatRoomId
+        ),
     ];
 
-    const persistenceRead : IPersistenceRead = read.getPersistenceReader();
-    const results = await persistenceRead.readByAssociations(associationsByRocketChatRoomId);
+    const persistenceRead: IPersistenceRead = read.getPersistenceReader();
+    const results = await persistenceRead.readByAssociations(
+        associationsByRocketChatRoomId
+    );
 
     if (results === undefined || results === null || results.length == 0) {
         return null;
     }
 
     if (results.length > 1) {
-        throw new Error(`More than one Room record for room ${rocketChatRoomId}`);
+        throw new Error(
+            `More than one Room record for room ${rocketChatRoomId}`
+        );
     }
 
-    const data : RoomModel = results[0] as RoomModel;
+    const data: RoomModel = results[0] as RoomModel;
 
     return data;
 };
 
 export const retrieveRoomByTeamsThreadIdAsync = async (
     read: IRead,
-    teamsThreadId: string) : Promise<RoomModel | null> => {
+    teamsThreadId: string
+): Promise<RoomModel | null> => {
     const associationsByRocketChatRoomId: Array<RocketChatAssociationRecord> = [
-        new RocketChatAssociationRecord(RocketChatAssociationModel.MISC, MiscKeys.Room),
-        new RocketChatAssociationRecord(RocketChatAssociationModel.MESSAGE, teamsThreadId),
+        new RocketChatAssociationRecord(
+            RocketChatAssociationModel.MISC,
+            MiscKeys.Room
+        ),
+        new RocketChatAssociationRecord(
+            RocketChatAssociationModel.MESSAGE,
+            teamsThreadId
+        ),
     ];
 
-    const persistenceRead : IPersistenceRead = read.getPersistenceReader();
-    const results = await persistenceRead.readByAssociations(associationsByRocketChatRoomId);
+    const persistenceRead: IPersistenceRead = read.getPersistenceReader();
+    const results = await persistenceRead.readByAssociations(
+        associationsByRocketChatRoomId
+    );
 
     if (results === undefined || results === null || results.length == 0) {
         return null;
     }
 
     if (results.length > 1) {
-        throw new Error(`More than one Room record for Teams thread ${teamsThreadId}`);
+        throw new Error(
+            `More than one Room record for Teams thread ${teamsThreadId}`
+        );
     }
 
-    const data : RoomModel = results[0] as RoomModel;
+    const data: RoomModel = results[0] as RoomModel;
 
     return data;
 };
 
-export const retrieveAllTeamsUserProfilesAsync = async (read: IRead) : Promise<TeamsUserProfileModel[] | null> => {
-    const association = new RocketChatAssociationRecord(RocketChatAssociationModel.MISC, MiscKeys.TeamsUserProfile);
+export const retrieveAllTeamsUserProfilesAsync = async (
+    read: IRead
+): Promise<Array<TeamsUserProfileModel> | null> => {
+    const association = new RocketChatAssociationRecord(
+        RocketChatAssociationModel.MISC,
+        MiscKeys.TeamsUserProfile
+    );
 
-    const persistenceRead : IPersistenceRead = read.getPersistenceReader();
+    const persistenceRead: IPersistenceRead = read.getPersistenceReader();
     const results = await persistenceRead.readByAssociation(association);
 
     if (results === undefined || results === null || results.length == 0) {
         return null;
     }
 
-    const data : TeamsUserProfileModel[] = results as TeamsUserProfileModel[];
+    const data: Array<TeamsUserProfileModel> =
+        results as Array<TeamsUserProfileModel>;
 
     return data;
 };
 
 export const retrieveOneDriveFileAsync = async (
     read: IRead,
-    fileName: string,
-) : Promise<OneDriveFileModel | null> => {
+    fileName: string
+): Promise<OneDriveFileModel | null> => {
     const associations: Array<RocketChatAssociationRecord> = [
-        new RocketChatAssociationRecord(RocketChatAssociationModel.MISC, MiscKeys.OneDriveFile),
-        new RocketChatAssociationRecord(RocketChatAssociationModel.FILE, fileName),
+        new RocketChatAssociationRecord(
+            RocketChatAssociationModel.MISC,
+            MiscKeys.OneDriveFile
+        ),
+        new RocketChatAssociationRecord(
+            RocketChatAssociationModel.FILE,
+            fileName
+        ),
     ];
 
-    const persistenceRead : IPersistenceRead = read.getPersistenceReader();
+    const persistenceRead: IPersistenceRead = read.getPersistenceReader();
     const results = await persistenceRead.readByAssociations(associations);
 
     if (results === undefined || results === null || results.length == 0) {
@@ -591,20 +848,29 @@ export const retrieveOneDriveFileAsync = async (
     }
 
     if (results.length > 1) {
-        throw new Error(`More than one OneDrive file record for file ${fileName}`);
+        throw new Error(
+            `More than one OneDrive file record for file ${fileName}`
+        );
     }
 
-    const data : OneDriveFileModel = results[0] as OneDriveFileModel;
+    const data: OneDriveFileModel = results[0] as OneDriveFileModel;
 
     return data;
 };
 
 export const deleteUserAccessTokenAsync = async (
     persis: IPersistence,
-    rocketChatUserId: string) : Promise<void> => {
+    rocketChatUserId: string
+): Promise<void> => {
     const associations: Array<RocketChatAssociationRecord> = [
-        new RocketChatAssociationRecord(RocketChatAssociationModel.MISC, MiscKeys.UserRegistration),
-        new RocketChatAssociationRecord(RocketChatAssociationModel.USER, rocketChatUserId),
+        new RocketChatAssociationRecord(
+            RocketChatAssociationModel.MISC,
+            MiscKeys.UserRegistration
+        ),
+        new RocketChatAssociationRecord(
+            RocketChatAssociationModel.USER,
+            rocketChatUserId
+        ),
     ];
 
     await persis.removeByAssociations(associations);
@@ -613,20 +879,35 @@ export const deleteUserAccessTokenAsync = async (
 export const deleteUserAsync = async (
     read: IRead,
     persis: IPersistence,
-    rocketChatUserId: string) : Promise<void> => {
-
-    const user = await retrieveUserByRocketChatUserIdAsync(read, rocketChatUserId);
+    rocketChatUserId: string
+): Promise<void> => {
+    const user = await retrieveUserByRocketChatUserIdAsync(
+        read,
+        rocketChatUserId
+    );
     if (!user) {
         return;
     }
 
     const associationsByRocketChatUserId: Array<RocketChatAssociationRecord> = [
-        new RocketChatAssociationRecord(RocketChatAssociationModel.MISC, MiscKeys.User),
-        new RocketChatAssociationRecord(RocketChatAssociationModel.USER, user.rocketChatUserId),
+        new RocketChatAssociationRecord(
+            RocketChatAssociationModel.MISC,
+            MiscKeys.User
+        ),
+        new RocketChatAssociationRecord(
+            RocketChatAssociationModel.USER,
+            user.rocketChatUserId
+        ),
     ];
     const associationsByTeamsUserId: Array<RocketChatAssociationRecord> = [
-        new RocketChatAssociationRecord(RocketChatAssociationModel.MISC, MiscKeys.User),
-        new RocketChatAssociationRecord(RocketChatAssociationModel.USER, user.teamsUserId),
+        new RocketChatAssociationRecord(
+            RocketChatAssociationModel.MISC,
+            MiscKeys.User
+        ),
+        new RocketChatAssociationRecord(
+            RocketChatAssociationModel.USER,
+            user.teamsUserId
+        ),
     ];
 
     await persis.removeByAssociations(associationsByRocketChatUserId);
@@ -635,8 +916,72 @@ export const deleteUserAsync = async (
 
 export const debugCleanAllRoomAsync = async (persis: IPersistence) => {
     const associations: Array<RocketChatAssociationRecord> = [
-        new RocketChatAssociationRecord(RocketChatAssociationModel.MISC, MiscKeys.Room),
+        new RocketChatAssociationRecord(
+            RocketChatAssociationModel.MISC,
+            MiscKeys.Room
+        ),
     ];
 
     await persis.removeByAssociations(associations);
+};
+
+export const saveLoginMessageSentStatus = async ({
+    persistence,
+    rocketChatUserId,
+    wasSent,
+}: {
+    persistence: IPersistence;
+    rocketChatUserId: string;
+    wasSent: boolean;
+}) => {
+    const associations: Array<RocketChatAssociationRecord> = [
+        new RocketChatAssociationRecord(
+            RocketChatAssociationModel.MISC,
+            MiscKeys.LoginMessage
+        ),
+        new RocketChatAssociationRecord(
+            RocketChatAssociationModel.USER,
+            rocketChatUserId
+        ),
+    ];
+
+    await persistence.updateByAssociations(
+        associations,
+        {
+            isLoginMessageSent: true,
+            rocketChatUserId,
+        },
+        wasSent
+    );
+};
+
+export const retrieveLoginMessageSentStatus = async ({
+    read,
+    rocketChatUserId,
+}: {
+    read: IRead;
+    rocketChatUserId: string;
+}): Promise<boolean> => {
+    const associations: Array<RocketChatAssociationRecord> = [
+        new RocketChatAssociationRecord(
+            RocketChatAssociationModel.MISC,
+            MiscKeys.LoginMessage
+        ),
+        new RocketChatAssociationRecord(
+            RocketChatAssociationModel.USER,
+            rocketChatUserId
+        ),
+    ];
+
+    const persistenceRead: IPersistenceRead = read.getPersistenceReader();
+
+    const result = (await persistenceRead.readByAssociations(
+        associations
+    )) as unknown as Array<boolean>;
+
+    if (!result) {
+        return false;
+    }
+
+    return result[0];
 };


### PR DESCRIPTION
When the user is not authenticated anymore or the auth token is expired, the whole channel is blocked by a message asking to authenticate.

With that in mind, this PR changes the blocking part and checks if the message was already sent by saving the message status on the persistence layer.