### PR TITLE
refactor_AuthenticationEndpoint

### DIFF
--- a/endpoints/AuthenticationEndpoint.ts
+++ b/endpoints/AuthenticationEndpoint.ts
@@ -1,156 +1,99 @@
 import {
-    HttpStatusCode,
-    IHttp,
-    IModify,
-    IPersistence,
-    IRead,
+  HttpStatusCode,
+  IHttp,
+  IModify,
+  IPersistence,
+  IRead,
 } from "@rocket.chat/apps-engine/definition/accessors";
 import {
-    ApiEndpoint,
-    IApiEndpointInfo,
-    IApiRequest,
-    IApiResponse,
+  ApiEndpoint,
+  IApiEndpointInfo,
+  IApiRequest,
+  IApiResponse,
 } from "@rocket.chat/apps-engine/definition/api";
 import { IApiResponseJSON } from "@rocket.chat/apps-engine/definition/api/IResponse";
 import { IApp } from "@rocket.chat/apps-engine/definition/IApp";
 import { AppSetting } from "../config/Settings";
 import {
-    AuthenticationEndpointPath,
-    SubscriberEndpointPath,
+  AuthenticationEndpointPath,
+  SubscriberEndpointPath,
 } from "../lib/Const";
 import {
-    getUserAccessTokenAsync,
-    getUserProfileAsync,
-    listSubscriptionsAsync,
-    subscribeToAllMessagesForOneUserAsync,
+  getUserAccessTokenAsync,
+  getUserProfileAsync,
+  listSubscriptionsAsync,
+  subscribeToAllMessagesForOneUserAsync,
 } from "../lib/MicrosoftGraphApi";
 import {
-    persistUserAccessTokenAsync,
-    persistUserAsync,
-    saveLoginMessageSentStatus,
+  persistUserAccessTokenAsync,
+  persistUserAsync,
+  saveLoginMessageSentStatus,
 } from "../lib/PersistHelper";
 import { getRocketChatAppEndpointUrl } from "../lib/UrlHelper";
 
 export class AuthenticationEndpoint extends ApiEndpoint {
-    private embeddedLoginSuccessMessage: string =
-        "Login to Teams succeed! You can close this window now.";
-    private embeddedLoginFailureMessage: string =
-        "Login to Teams failed! Please check document or contact your organization admin.";
+  private embeddedLoginSuccessMessage = "Login to Teams succeed! You can close this window now.";
+  private embeddedLoginFailureMessage = "Login to Teams failed! Please check the documentation or contact your organization admin.";
 
-    public path = AuthenticationEndpointPath;
+  public path = AuthenticationEndpointPath;
 
-    constructor(app: IApp) {
-        super(app);
-        this.errorResponse = this.errorResponse.bind(this);
+  constructor(app: IApp) {
+    super(app);
+    this.errorResponse = this.errorResponse.bind(this);
+  }
+
+  public async get(
+    request: IApiRequest,
+    endpoint: IApiEndpointInfo,
+    read: IRead,
+    modify: IModify,
+    http: IHttp,
+    persist: IPersistence
+  ): Promise<IApiResponse> {
+    if (request.query.error && !request.query.code) {
+      return this.errorResponse();
     }
 
-    public async get(
-        request: IApiRequest,
-        endpoint: IApiEndpointInfo,
-        read: IRead,
-        modify: IModify,
-        http: IHttp,
-        persis: IPersistence
-    ): Promise<IApiResponse> {
-        if (request.query.error && !request.query.code) {
-            return this.errorResponse();
-        }
+    try {
+      const aadTenantId = await this.getAppSetting(read, AppSetting.AadTenantId);
+      const aadClientId = await this.getAppSetting(read, AppSetting.AadClientId);
+      const aadClientSecret = await this.getAppSetting(read, AppSetting.AadClientSecret);
 
-        try {
-            const aadTenantId = (
-                await read
-                    .getEnvironmentReader()
-                    .getSettings()
-                    .getById(AppSetting.AadTenantId)
-            ).value;
-            const aadClientId = (
-                await read
-                    .getEnvironmentReader()
-                    .getSettings()
-                    .getById(AppSetting.AadClientId)
-            ).value;
-            const aadClientSecret = (
-                await read
-                    .getEnvironmentReader()
-                    .getSettings()
-                    .getById(AppSetting.AadClientSecret)
-            ).value;
+      const rocketChatUserId = request.query.state;
+      const accessCode = request.query.code;
+      const authEndpointUrl = await getRocketChatAppEndpointUrl(this.app.getAccessors(), AuthenticationEndpointPath);
 
-            const rocketChatUserId: string = request.query.state;
-            const accessCode: string = request.query.code;
-            const authEndpointUrl = await getRocketChatAppEndpointUrl(
-                this.app.getAccessors(),
-                AuthenticationEndpointPath
-            );
+      const response = await getUserAccessTokenAsync(
+        http,
+        accessCode,
+        authEndpointUrl,
+        aadTenantId,
+        aadClientId,
+        aadClientSecret
+      );
 
-            const response = await getUserAccessTokenAsync(
-                http,
-                accessCode,
-                authEndpointUrl,
-                aadTenantId,
-                aadClientId,
-                aadClientSecret
-            );
+      const { accessToken: userAccessToken, refreshToken, expiresIn, extExpiresIn } = response;
 
-            const userAccessToken = response.accessToken;
+      const teamsUserProfile = await getUserProfileAsync(http, userAccessToken);
 
-            const teamsUserProfile = await getUserProfileAsync(
-                http,
-                userAccessToken
-            );
+      await Promise.all([
+        persistUserAccessTokenAsync(persist, rocketChatUserId, userAccessToken, refreshToken as string, expiresIn, extExpiresIn),
+        persistUserAsync(persist, rocketChatUserId, teamsUserProfile.id),
+        saveLoginMessageSentStatus({ persistence: persist, rocketChatUserId, wasSent: false }),
+      ]);
 
-            await Promise.all([
-                persistUserAccessTokenAsync(
-                    persis,
-                    rocketChatUserId,
-                    userAccessToken,
-                    response.refreshToken as string,
-                    response.expiresIn,
-                    response.extExpiresIn
-                ),
-                persistUserAsync(persis, rocketChatUserId, teamsUserProfile.id),
-                saveLoginMessageSentStatus({
-                    persistence: persis,
-                    rocketChatUserId,
-                    wasSent: false,
-                }),
-            ]);
+      const subscriptions = await listSubscriptionsAsync(http, userAccessToken);
+      if (!subscriptions || subscriptions.length === 0) {
+        const subscriberEndpointUrl = await getRocketChatAppEndpointUrl(this.app.getAccessors(), SubscriberEndpointPath);
+        subscribeToAllMessagesForOneUserAsync(http, rocketChatUserId, teamsUserProfile.id, subscriberEndpointUrl, userAccessToken);
+      }
 
-            // Only create subscription if there's no existing one to prevent error
-            const subscriptions = await listSubscriptionsAsync(
-                http,
-                userAccessToken
-            );
-            if (!subscriptions || subscriptions.length == 0) {
-                const subscriberEndpointUrl = await getRocketChatAppEndpointUrl(
-                    this.app.getAccessors(),
-                    SubscriberEndpointPath
-                );
-
-                // Async operation to create subscription
-                subscribeToAllMessagesForOneUserAsync(
-                    http,
-                    rocketChatUserId,
-                    teamsUserProfile.id,
-                    subscriberEndpointUrl,
-                    userAccessToken
-                );
-            }
-
-            return this.success(this.embeddedLoginSuccessMessage);
-        } catch (error) {
-            return this.errorResponse();
-        }
+      return this.success(this.embeddedLoginSuccessMessage);
+    } catch (error) {
+      return this.errorResponse();
     }
+  }
 
-    private errorResponse(): IApiResponse {
-        const response: IApiResponseJSON = {
-            status: HttpStatusCode.BAD_REQUEST,
-            content: {
-                message: this.embeddedLoginFailureMessage,
-            },
-        };
-
-        return response;
-    }
-}
+  private async getAppSetting(read: IRead, settingId: AppSetting): Promise<string> {
+    const setting = await read.getEnvironmentReader().getSettings().getById(settingId);
+   


### PR DESCRIPTION
    Removed explicit type declarations for private properties: Since TypeScript can infer the types based on the assigned values, there's no need to explicitly specify the types for embeddedLoginSuccessMessage and embeddedLoginFailureMessage. The types will be inferred as string automatically.

    Renamed persis parameter to persist: The parameter name persis was a typo and didn't match the actual parameter name used in the code (persist). I corrected the parameter name to match the usage in the method.

    Extracted common logic to a separate method: I created a new private method called getAppSetting to handle the retrieval of app settings. This method takes the read accessor and the settingId as parameters, and it returns the value of the specified app setting. This extraction improves code readability and eliminates code duplication.