### PR TITLE
feat: new message parser and bug fixes

### DIFF
--- a/TeamsBridgeApp.ts
+++ b/TeamsBridgeApp.ts
@@ -122,10 +122,7 @@ export class TeamsBridgeApp
     }
 
     async executePreMessageSentModify(message: IMessage, builder: IMessageBuilder, read: IRead, http: IHttp, persistence: IPersistence) {
-        console.log("Before modification: " + JSON.stringify(message, null, 2));
         let extraInfoData = popExtraInfoAttachment(message);
-        console.log("After popExtraInfoAttachment: " + JSON.stringify(message, null, 2));
-        console.log("Extra info data: " + JSON.stringify(extraInfoData, null, 2));
         if (extraInfoData.source === 'ms-teams') {
            await PreventRegistry.set(
                persistence,
@@ -143,7 +140,6 @@ export class TeamsBridgeApp
                 return false;
             }
             const { originalFilename, present, extraInfo } = getExtraInfoAndOriginalFileName(att.title.value);
-            console.log(`Attachment[${i}] - originalFilename: ${originalFilename}, present: ${present}, extraInfo: ${JSON.stringify(extraInfo)}`);
             if (present) {
                 extraInfoData = extraInfo;
                 pos = i;
@@ -158,7 +154,6 @@ export class TeamsBridgeApp
                 `PreventPostMessageHook/${message.id}`,
                 true
             );
-            console.log(`Extra info found in attachment title: ${JSON.stringify(extraInfoData)}`);
             if (Array.isArray(message["_unmappedProperties_"]?.['files'])) {
                 message["_unmappedProperties_"]['files'] = message["_unmappedProperties_"]['files'].map((file) => {
                     if (file.name === message.attachments![pos].title?.value) {
@@ -183,7 +178,6 @@ export class TeamsBridgeApp
             if (message.file && originalFilenameFound) {
                 message.file = { ...message.file, name: originalFilenameFound };
             }
-            console.log("result from preMessageSentModify:", JSON.stringify({ message }, null, 2));
             return message;
         }
         return message;

--- a/app.json
+++ b/app.json
@@ -1,6 +1,6 @@
 {
     "id": "30d2e4bf-2402-4197-b844-e7082b07dc65",
-    "version": "0.1.0",
+    "version": "1.0.0",
     "requiredApiVersion": "^1.40.0",
     "iconFile": "icon.png",
     "author": {

--- a/app.json
+++ b/app.json
@@ -24,6 +24,7 @@
         "IPostMessageDeleted",
         "IPreMessageDeletePrevent",
         "IPreFileUpload",
+        "IPreMessageSentModify",
         "IPreRoomUserLeave"
     ],
     "permissions": [

--- a/endpoints/SubscriberEndpoint.ts
+++ b/endpoints/SubscriberEndpoint.ts
@@ -10,9 +10,8 @@ import {
     IApiRequest,
     IApiResponse,
 } from "@rocket.chat/apps-engine/definition/api";
-import { SubscriberEndpointPath } from "../lib/Const";
+import { IncomingNotificationProcessorId, SubscriberEndpointPath } from "../lib/Const";
 import {
-    handleInboundNotificationAsync,
     InBoundNotification,
     NotificationChangeType,
     NotificationResourceType,
@@ -113,13 +112,10 @@ export class SubscriberEndpoint extends ApiEndpoint {
                     resourceType: resourceType,
                 };
 
-                await handleInboundNotificationAsync({
-                    inBoundNotification,
-                    read,
-                    modify,
-                    http,
-                    persistence: persis,
-                    app: this.app,
+                await modify.getScheduler().scheduleOnce({
+                    when: new Date(),
+                    data: { inBoundNotification },
+                    id: IncomingNotificationProcessorId,
                 });
             } catch (error) {
                 // If there's an error, print a warning but not block the whole process

--- a/jobs/InboundNotificationProcessor.ts
+++ b/jobs/InboundNotificationProcessor.ts
@@ -1,0 +1,18 @@
+import { IRead, IModify, IHttp, IPersistence } from '@rocket.chat/apps-engine/definition/accessors';
+import { IJobContext, IProcessor } from '@rocket.chat/apps-engine/definition/scheduler';
+import { handleInboundNotificationAsync } from '../lib/InboundNotificationHelper';
+import { IncomingNotificationProcessorId } from '../lib/Const';
+export class InboundNotificationProcessor implements IProcessor {
+    id = IncomingNotificationProcessorId;
+    constructor(private readonly app: any) {}
+    async processor(jobContext: IJobContext, read: IRead, modify: IModify, http: IHttp, persistence: IPersistence): Promise<void> {
+        await handleInboundNotificationAsync({
+            app: this.app,
+            read,
+            modify,
+            http,
+            inBoundNotification: jobContext.inBoundNotification,
+            persistence
+        })
+    }
+}

--- a/lib/Const.ts
+++ b/lib/Const.ts
@@ -54,9 +54,9 @@ export const LoginRequiredHintMessageText: string =
 export const LoginNoNeedHintMessageText: string = 'You have already login Microsoft Teams to start cross platform collaboration for your account. '
     + 'No need to login again.';
 export const LoggedInBridgeUserRequiredHintMessageText: string =
-    'The Rocket.Chat room you are messaging includes at least one Teams Bot user that represents a colleague in your organization using Microsoft Teams. '
-    + 'The message can NOT be delivered to Microsoft Teams before there is at least one user in this room start cross platform collaboration. '
-    + 'To start cross platform collaboration for your account, please click this button to login Teams:';
+    "This Rocket.Chat room includes at least one Teams Bot user representing a colleague from Microsoft Teams. " +
+    "Your message cannot be delivered to Microsoft Teams until at least one user in this room has started cross-platform collaboration. " +
+    "To enable cross-platform collaboration for your account, please click the button below to log in to Microsoft Teams:";
 export const UnsupportedScenarioHintMessageText = (scenario: string) =>
     `${scenario} is not supported by TeamsBridge app for cross platform collaboration.`
     + ' This message won\'t be delivered to target user on Teams.';

--- a/lib/Const.ts
+++ b/lib/Const.ts
@@ -101,7 +101,10 @@ export const MicrosoftFileUrlPrefix = 'https://graph.microsoft.com';
 
 export const SharePointUrl = 'sharepoint.com';
 
-export const FileAttachmentContentType = 'reference';
+export const TeamsAttachmentType = {
+    File: "reference",
+    MessageReference: "messageReference",
+};
 
 export const TeamsAppUserNameSurfix = 'msteams.alias';
 
@@ -110,6 +113,8 @@ export const RegistrationAutoRenewSchedulerId = 'registration.auto.renew.schedul
 export const RegistrationAutoRenewInterval = '1800 seconds';
 
 export const WebhookSecretCreationJobId = 'teamsbridge.secret.creation.job';
+
+export const IncomingNotificationProcessorId = 'teamsbridge.incoming.notification.processor';
 
 export const DefaultThreadName = 'Rocket.Chat interop group';
 

--- a/lib/EventHandler.ts
+++ b/lib/EventHandler.ts
@@ -748,12 +748,6 @@ export const handlePostMessageDeletedAsync = async (options: {
             uploadMappings,
         });
 
-    console.log("[Bridge] Combined Teams Message:", text);
-    console.log(
-        "[Bridge] Should delete Teams message?",
-        shouldDeleteTeamsMessage
-    );
-
     // --- Step 5: Execute Teams update/delete ---
     if (shouldDeleteTeamsMessage) {
         await deleteTextMessageInChatThreadAsync(

--- a/lib/InboundNotificationHelper.ts
+++ b/lib/InboundNotificationHelper.ts
@@ -1,5 +1,4 @@
 import {
-    IAppAccessors,
     IHttp,
     IModify,
     IPersistence,
@@ -315,6 +314,17 @@ const handleInboundMessageCreatedAsync = async (
 
             if (message.text === "") {
                 // File message, no text content
+                await Promise.all(
+                    message.uploadIds.map((uploadIdMap) => {
+                        return persistUploadAndTeamsMappingAsync({
+                            persistence: persis,
+                            rocketchatUploadId: uploadIdMap.rocketChat,
+                            teamsAttachmentId: uploadIdMap.teams,
+                            teamsMessageId: getMessageResponse.messageId,
+                            teamsThreadId: getMessageResponse.threadId,
+                        });
+                    }),
+                );
                 return;
             }
 

--- a/lib/MessageHelper.ts
+++ b/lib/MessageHelper.ts
@@ -1,6 +1,5 @@
 import {
     IHttp,
-    IHttpRequest,
     IMessageBuilder,
     IModify,
     IModifyCreator,
@@ -13,8 +12,9 @@ import { IRoom, RoomType } from "@rocket.chat/apps-engine/definition/rooms";
 import { IUploadDescriptor } from "@rocket.chat/apps-engine/definition/uploads/IUploadDescriptor";
 import { IUser } from "@rocket.chat/apps-engine/definition/users";
 import { shortnameToUnicode } from "emojione";
-import { FileAttachmentContentType, LoginButtonText, MicrosoftFileUrlPrefix, SharePointUrl } from "./Const";
+import { LoginButtonText, MicrosoftFileUrlPrefix, SharePointUrl, TeamsAttachmentType } from "./Const";
 import { downloadOneDriveFileAsync, GetMessageResponse, MessageContentType } from "./MicrosoftGraphApi";
+import { buildRocketChatMessageText, parseHTML } from "./TeamsMessageParser";
 
 export const sendRocketChatOneOnOneMessageAsync = async (
     message: string,
@@ -54,7 +54,8 @@ export const sendRocketChatMessageInRoomAsync = async (
     const message : IMessage = {
         text: messageText,
         sender,
-        room
+        room,
+        attachments: [await buildExtraInfoAttachment({ source: 'ms-teams' })],
     }
 
     const messageBuilder: IMessageBuilder = creator.startMessage(message as IMessage);
@@ -112,72 +113,83 @@ export const generateHintMessageWithTeamsLoginButton = (
     return message;
 };
 
-export const mapTeamsMessageToRocketChatMessage = (
+export const mapTeamsMessageToRocketChatMessage = async ({
+    getMessageResponse,
+    read,
+    accessToken,
+    modify,
+    room,
+    sender,
+    http,
+    uploadFiles,
+}: {
     getMessageResponse: GetMessageResponse,
-    accessToken: string,
+    read: IRead,
+    accessToken: string
     room: IRoom,
     sender: IUser,
+    modify: IModify,
     http: IHttp,
-    modify: IModify) : string => {
-    const teamsMessage = getMessageResponse.messageContent;
-    const contentType = getMessageResponse.messageContentType;
-
-    console.log("Mapping Teams message format to Rocket.Chat message format.");
-
-    let rocketChatMessage = teamsMessage;
-    if (contentType && contentType === MessageContentType.Html) {
-        // TODO: find a better way to trim html tag from html messages
-        const nbspPattern = /&nbsp;/g;
-        const htmpTagPattern = /<\/?[^>]+>/g;
-
-        rocketChatMessage = rocketChatMessage.replace(nbspPattern, ' ');
-        rocketChatMessage = rocketChatMessage.replace(htmpTagPattern, match => {
-            if (match.indexOf('itemtype="http://schema.skype.com/Emoji"') > 0) {
-                const index = match.indexOf('alt="');
-                return match.substring(index + 5, index + 7);
-            }
-
-            if (match.indexOf('img') > 0) {
-                const urlStartIndex = match.indexOf('src="');
-                const urlPrefixString = match.substring(urlStartIndex + 5);
-                const urlEndIndex = urlPrefixString.indexOf('"');
-                const url = urlPrefixString.substring(0, urlEndIndex);
-
-                const fileNameStartIndex = match.indexOf('alt="');
-                const fileNamePrefixString = match.substring(fileNameStartIndex + 5);
-                const fileNameEndIndex = fileNamePrefixString.indexOf('"');
-                const fileName = fileNamePrefixString.substring(0, fileNameEndIndex);
-
-                downloadInlineImgFromExternalAndUploadToRocketChatAsync(url, fileName, accessToken, room, sender, http, modify);
-
-                return '';
-            }
-
-            if (match.indexOf('attachment') > 0) {
-                const attachmentIdStartIndex = match.indexOf('id="');
-                const attachmentIdPrefixString = match.substring(attachmentIdStartIndex + 4);
-                const attachmentIdEndIndex = attachmentIdPrefixString.indexOf('"');
-                const attachmentId = attachmentIdPrefixString.substring(0, attachmentIdEndIndex);
-
-                if (getMessageResponse.attachments) {
-                    for (const attachment of getMessageResponse.attachments) {
-                        if (attachment.id === attachmentId && attachment.contentType === FileAttachmentContentType) {
-                            const fileName = attachment.name;
-                            const url = attachment.contentUrl;
-
-                            downloadAttachmentFileFromExternalAndUploadToRocketChatAsync(url, fileName, accessToken, room, sender, http, modify);
-
-                            return '';
+    uploadFiles: boolean,
+}): Promise<{
+    text: string;
+    uploadIds: {
+        rocketChat: string;
+        teams: string;
+    }[];
+}> => {
+    const { messageContent, messageContentType, attachments } = getMessageResponse;
+    let uploadIds: { rocketChat: string; teams: string }[] = [];
+    let text = messageContent;
+    if (attachments && attachments.length > 0) {
+        if (uploadFiles) {
+            const attachmentsToUpload = attachments.filter(
+                (a) => a.contentType === TeamsAttachmentType.File
+            );
+           (
+                await Promise.all(
+                    attachmentsToUpload.map(async (attachment) => {
+                        const { contentUrl, name, id } = attachment;
+                        if (contentUrl && name) {
+                            try {
+                                const upload = await downloadAttachmentFileFromExternalAndUploadToRocketChatAsync(
+                                    {
+                                        url: contentUrl,
+                                        fileName: name,
+                                        accessToken,
+                                        room,
+                                        sender,
+                                        http,
+                                        modify,
+                                    }
+                                );
+                                return upload;
+                            } catch (error) {
+                                console.error(
+                                    `Error downloading attachment: ${error.message}`
+                                );
+                                return Promise.resolve(null);
+                            }
                         }
-                    }
+                        return Promise.resolve(null);
+                    })
+                )
+            ).forEach((upload, index) => {
+                if (upload) {
+                    uploadIds.push({ rocketChat: upload.id, teams: attachments[index].id });
                 }
-            }
-
-            return '';
-        });
+            })
+        }
+    }
+    if (messageContentType && messageContentType === MessageContentType.Html) {
+        const parsedNodes = parseHTML(messageContent);
+        text = await buildRocketChatMessageText({ nodes: parsedNodes, attachments, read });
     }
 
-    return rocketChatMessage;
+    return {
+        text,
+        uploadIds,
+    }
 };
 
 export const mapRocketChatMessageToTeamsMessage = (rocketChatMessage: string, originalSenderName?: string) : string => {
@@ -202,62 +214,34 @@ export const mapRocketChatMessageToTeamsMessage = (rocketChatMessage: string, or
     return teamsMessage;
 };
 
-const downloadAttachmentFileFromExternalAndUploadToRocketChatAsync = async (
+const downloadAttachmentFileFromExternalAndUploadToRocketChatAsync = async ({
+    url,
+    fileName,
+    accessToken,
+    room,
+    sender,
+    http,
+    modify,
+}: {
     url: string,
     fileName: string,
     accessToken: string,
     room: IRoom,
     sender: IUser,
     http: IHttp,
-    modify: IModify) : Promise<void> => {
-    const encodedUrl = `u!${base64Encode(url).replace(/=+$/, '').replace('/','_').replace('+','-')}`;
+    modify: IModify,
+}) => {
+    const encodedUrl = `u!${base64Encode(url).replace(/=+$/, '').replace('/', '_').replace('+', '-')}`;
 
     const buff = await downloadOneDriveFileAsync(http, encodedUrl, accessToken);
     const uploadCreator = modify.getCreator().getUploadCreator();
     const fileInfo: IUploadDescriptor = {
-        filename: fileName,
+        filename: buildExtraInfoFileName(fileName, { source: 'ms-teams' }),
         room: room,
         user: sender
     };
 
-    await uploadCreator.uploadBuffer(buff, fileInfo);
-};
-
-const downloadInlineImgFromExternalAndUploadToRocketChatAsync = async (
-    url: string,
-    fileName: string,
-    accessToken: string,
-    room: IRoom,
-    sender: IUser,
-    http: IHttp,
-    modify: IModify) : Promise<void> => {
-    const httpRequest: IHttpRequest = {
-        encoding: null
-    };
-
-    if (url.startsWith(MicrosoftFileUrlPrefix) || url.indexOf(SharePointUrl)) {
-        // Auth Required
-        httpRequest.headers = {
-            'Authorization': `Bearer ${accessToken}`,
-        };
-    }
-
-    const response = await http.get(url, httpRequest);
-    let fileMIMEType = '';
-    if (response.headers) {
-        fileMIMEType = response.headers['content-type'];
-    }
-    const imgStr = response.content as string;
-    const buff = Buffer.from(imgStr, 'binary');
-
-    const uploadCreator = modify.getCreator().getUploadCreator();
-    const imgInfo: IUploadDescriptor = {
-        filename: `${fileName}.${fileMIMEType.split('/')[1]}`,
-        room: room,
-        user: sender
-    };
-
-    await uploadCreator.uploadBuffer(buff, imgInfo);
+    return uploadCreator.uploadBuffer(buff, fileInfo);
 };
 
 const getTeamsMessageUrl = (url: string): string => {
@@ -277,3 +261,84 @@ const getBridgedMessageFormat = (originalSenderName: string, message: string): s
 
 const base64Encode = (str: string):string => Buffer.from(str, 'binary').toString('base64');
 
+export const buildExtraInfoAttachment = (data: any) => {
+    const attachment: IMessageAttachment = {
+        imageUrl: `data:image/svg+xml,<?xml version="1.0" encoding="UTF-8"?><svg viewBox="0 0 120 12" xmlns="http://www.w3.org/2000/svg"><text dominant-baseline="hanging" fill="currentColor" font-family="Arial, sans-serif" font-size="12">by MS Teams Bridge</text><metadata>${JSON.stringify({ extraInfo: data })}</metadata></svg>`,
+        type: 'image/svg+xml',
+        collapsed: true,
+    };
+    return attachment;
+};
+
+export const popExtraInfoAttachment = (message: IMessage) => {
+    const data = {} as any;
+    const extraInfoAttachment = message.attachments?.find((att) => {
+        const match = att.imageUrl?.match(/<metadata>([\s\S]*?)<\/metadata>/);
+        if (match) {
+            try {
+                const parsedData = JSON.parse(match[1]);
+                if ('extraInfo' in parsedData) {
+                    Object.assign(data, parsedData.extraInfo);
+                    return true;
+                }
+                return false;
+            } catch {
+                return false;
+            }
+        }
+        return false;
+    });
+    if (extraInfoAttachment) {
+        message.attachments = message.attachments?.filter(att => att !== extraInfoAttachment);
+    }
+    return data;
+};
+
+
+export const buildExtraInfoFileName = (
+    originalFilename: string,
+    data: any
+): string => {
+    // Encode metadata as base64
+    const encoded = Buffer.from(
+        JSON.stringify({ extraInfo: data }),
+        "utf8"
+    ).toString("base64");
+
+    // Insert before extension
+    const lastDot = originalFilename.lastIndexOf(".");
+    if (lastDot !== -1) {
+        const name = originalFilename.slice(0, lastDot);
+        const ext = originalFilename.slice(lastDot); // includes the dot
+        return `${name}__extradata_${encoded}${ext}`;
+    }
+
+    // No extension case
+    return `${originalFilename}__extradata_${encoded}`;
+};
+export const getExtraInfoAndOriginalFileName = (filename: string): { originalFilename: string; extraInfo: any; present: boolean } => {
+    if (!filename) {
+        return { originalFilename: '', extraInfo: {}, present: false };
+    }
+
+    // Match: <name>__extradata_<base64>[.<ext>]
+    const match = filename.match(/^(.*)__extradata_([^.]*)/);
+    if (!match) {
+        return { originalFilename: filename, extraInfo: {}, present: false };
+    }
+
+    const [ , baseName, encoded ] = match;
+    const ext = filename.slice((baseName + `__extradata_${encoded}`).length);
+
+    try {
+        const decoded = Buffer.from(encoded, "base64").toString("utf8");
+        const { extraInfo } = JSON.parse(decoded);
+        return {
+            originalFilename: baseName + ext,
+            extraInfo: extraInfo ?? {},
+            present: true,
+        };
+    } catch {
+        return { originalFilename: filename, extraInfo: {}, present: false };
+    }
+};

--- a/lib/MicrosoftGraphApi.ts
+++ b/lib/MicrosoftGraphApi.ts
@@ -85,10 +85,27 @@ export enum MessageContentType {
 export interface Attachment {
     id: string,
     contentType: string,
-    contentUrl: string,
-    name: string,
+    contentUrl: string | null,
+    name: string | null,
 };
 
+export interface TeamsMessageReaction {
+    reactionType: string; // e.g., "😆"
+    displayName: string; // e.g., "Laugh"
+    reactionContentUrl: string | null;
+    createdDateTime: string; // ISO datetime string
+    user: {
+        application: string | null;
+        device: string | null;
+        user: {
+            "@odata.type": "#microsoft.graph.teamworkUserIdentity";
+            id: string;
+            displayName: string | null;
+            userIdentityType: "aadUser" | string;
+            tenantId: string;
+        };
+    };
+}
 export interface GetMessageResponse {
     threadId: string;
     messageId: string;
@@ -98,6 +115,7 @@ export interface GetMessageResponse {
     messageContent: string;
     attachments?: Attachment[];
     memberIds?: string[];
+    reactions?: TeamsMessageReaction[];
 };
 
 export interface UploadFileResponse {
@@ -782,6 +800,7 @@ export const getMessageWithResourceStringAsync = async (
             messageContent: responseBody.body?.content,
             attachments: attachments,
             memberIds: memberIds,
+            reactions: responseBody.reactions,
         };
 
         return result;
@@ -983,8 +1002,6 @@ export const subscribeToAllMessagesForOneUserAsync = async (options: {
         const existingSubscriptions = await listSubscriptionsAsync(http, userAccessToken, notificationUrl) || [];
 
         if (existingSubscriptions.length > 0) {
-
-            console.log(`Subscription expires`);
             if (existingSubscriptions.length > 1) {
                 await Promise.all(
                     existingSubscriptions

--- a/lib/MicrosoftGraphApi.ts
+++ b/lib/MicrosoftGraphApi.ts
@@ -693,6 +693,7 @@ export const sendFileMessageToChatThreadAsync = async (
 export const updateTextMessageInChatThreadAsync = async (
     http: IHttp,
     textMessage: string,
+    messageType: 'text' | 'html',
     messageId: string,
     threadId: string,
     userAccessToken: string) : Promise<void> => {
@@ -700,8 +701,9 @@ export const updateTextMessageInChatThreadAsync = async (
 
     const body = {
         'body' : {
-            'content': textMessage
-        }
+            'content': textMessage,
+            'contentType': messageType
+        },
     }
 
     const httpRequest: IHttpRequest = {
@@ -740,7 +742,8 @@ export const deleteTextMessageInChatThreadAsync = async (
     if (response.statusCode === HttpStatusCode.NO_CONTENT) {
         return;
     } else {
-        throw new Error(`Delete message in chat thread failed with http status code ${response.statusCode}.`);
+        console.log(`Response Error: ${response.content}`)
+        // throw new Error(`Delete message in chat thread failed with http status code ${response.statusCode}.`);
     }
 };
 

--- a/lib/MicrosoftGraphApi.ts
+++ b/lib/MicrosoftGraphApi.ts
@@ -742,8 +742,8 @@ export const deleteTextMessageInChatThreadAsync = async (
     if (response.statusCode === HttpStatusCode.NO_CONTENT) {
         return;
     } else {
-        console.log(`Response Error: ${response.content}`)
-        // throw new Error(`Delete message in chat thread failed with http status code ${response.statusCode}.`);
+        //  console.log(`Response Error: ${response.content}`)
+        throw new Error(`Delete message in chat thread failed with http status code ${response.statusCode}.`);
     }
 };
 

--- a/lib/PreventRegistry.ts
+++ b/lib/PreventRegistry.ts
@@ -27,13 +27,10 @@ export class PreventRegistry {
             ),
         ];
 
-        console.log(`PreventRegistry set: ${key}`);
-
         await persistence.updateByAssociations(associations, { ...(value && { value }) }, true);
     }
 
     public static async capture(persistence: IPersistence, key: string) {
-        console.log(`PreventRegistry capture started: ${key}`);
         const associations = [
             new RocketChatAssociationRecord(
                 RocketChatAssociationModel.MISC,
@@ -50,11 +47,7 @@ export class PreventRegistry {
         if (!data) {
             return null;
         }
-        if (data.length > 0) {
-            console.log(`PreventRegistry captured: ${data.join(", ").toString()}`);
-        } else {
-            console.log(`PreventRegistry capture failed: ${key}`);
-        }
+
         return data.shift() ?? null;
     }
 

--- a/lib/PreventRegistry.ts
+++ b/lib/PreventRegistry.ts
@@ -1,0 +1,94 @@
+import { IPersistence } from "@rocket.chat/apps-engine/definition/accessors";
+import {
+    RocketChatAssociationModel,
+    RocketChatAssociationRecord,
+} from "@rocket.chat/apps-engine/definition/metadata";
+import { MiscKeys } from "./PersistHelper";
+
+/**
+ * This class will help preventing a task from being executed multiple times.
+ * It provides methods to set, capture, clear, and release tasks.
+ * It uses a persistence layer to store the key related to each task.
+ */
+export class PreventRegistry {
+    public static async set(
+        persistence: IPersistence,
+        key: string,
+        value?: any,
+    ): Promise<void> {
+        const associations = [
+            new RocketChatAssociationRecord(
+                RocketChatAssociationModel.MISC,
+                MiscKeys.PreventRegistry
+            ),
+            new RocketChatAssociationRecord(
+                RocketChatAssociationModel.MISC,
+                key,
+            ),
+        ];
+
+        console.log(`PreventRegistry set: ${key}`);
+
+        await persistence.updateByAssociations(associations, { ...(value && { value }) }, true);
+    }
+
+    public static async capture(persistence: IPersistence, key: string) {
+        console.log(`PreventRegistry capture started: ${key}`);
+        const associations = [
+            new RocketChatAssociationRecord(
+                RocketChatAssociationModel.MISC,
+                MiscKeys.PreventRegistry
+            ),
+            new RocketChatAssociationRecord(
+                RocketChatAssociationModel.MISC,
+                key
+            ),
+        ];
+
+        const data = await persistence.removeByAssociations(associations);
+
+        if (!data) {
+            return null;
+        }
+        if (data.length > 0) {
+            console.log(`PreventRegistry captured: ${data.join(", ").toString()}`);
+        } else {
+            console.log(`PreventRegistry capture failed: ${key}`);
+        }
+        return data.shift() ?? null;
+    }
+
+    public static async captureMany(
+        persistence: IPersistence,
+        keys: string[]
+    ): Promise<boolean> {
+        const results = await Promise.all(keys.map(key => this.capture(persistence, key)));
+        return results.some(Boolean);
+    }
+
+    public static async clear(persistence: IPersistence) {
+        const associations = [
+            new RocketChatAssociationRecord(
+                RocketChatAssociationModel.MISC,
+                MiscKeys.PreventRegistry
+            ),
+        ];
+
+        await persistence.removeByAssociations(associations);
+    }
+
+    public static async release(persistence: IPersistence, key: string) {
+        const associations = [
+            new RocketChatAssociationRecord(
+                RocketChatAssociationModel.MISC,
+                MiscKeys.PreventRegistry
+            ),
+            new RocketChatAssociationRecord(
+                RocketChatAssociationModel.MISC,
+                key
+            ),
+        ];
+
+        await persistence.removeByAssociations(associations);
+    }
+}

--- a/lib/RocketChatMessageParser.ts
+++ b/lib/RocketChatMessageParser.ts
@@ -281,7 +281,15 @@ const esc = (s: string) =>
             }[c]!)
     );
 
-const stripHtml = (s: string) => s.replace(/<[^>]*>/g, "");
+// Note: For robust HTML sanitization, consider using a library like 'sanitize-html'
+const stripHtml = (s: string) => {
+    let prev;
+    do {
+        prev = s;
+        s = s.replace(/<[^>]*>/g, "");
+    } while (s !== prev);
+    return s;
+};
 
 export const createTeamsHTMLMessage = (root: Root, siteUrl: string) => {
     const renderChildren = (arr: AnyNode[] | undefined) =>

--- a/lib/RocketChatMessageParser.ts
+++ b/lib/RocketChatMessageParser.ts
@@ -1,0 +1,437 @@
+import { shortnameToUnicode } from "emojione";
+
+export type Blockquote = {
+    type: "BLOCKQUOTE";
+    value: Paragraph[];
+};
+
+export type OrderedList = {
+    type: "ORDERED_LIST";
+    value: ListItem[];
+};
+
+export type UnorderedList = {
+    type: "UNORDERED_LIST";
+    value: ListItem[];
+};
+
+export type ListItem = {
+    type: "LIST_ITEM";
+    value: Inlines[];
+    number?: number;
+};
+
+export type Tasks = {
+    type: "TASKS";
+    value: Task[];
+};
+export type Task = {
+    type: "TASK";
+    status: boolean;
+    value: Inlines[];
+};
+
+export type CodeLine = {
+    type: "CODE_LINE";
+    value: Plain;
+};
+
+export type Color = {
+    type: "COLOR";
+    value: {
+        r: number;
+        g: number;
+        b: number;
+        a: number;
+    };
+};
+
+export type BigEmoji = {
+    type: "BIG_EMOJI";
+    value: [Emoji] | [Emoji, Emoji] | [Emoji, Emoji, Emoji];
+};
+
+export type Emoji =
+    | {
+          type: "EMOJI";
+          value: Plain;
+          shortCode: string;
+      }
+    | {
+          type: "EMOJI";
+          value: undefined;
+          unicode: string;
+      };
+
+export type Code = {
+    type: "CODE";
+    language: string | undefined;
+    value: CodeLine[];
+};
+
+export type InlineCode = {
+    type: "INLINE_CODE";
+    value: Plain;
+};
+
+export type Heading = {
+    type: "HEADING";
+    level: 1 | 2 | 3 | 4;
+    value: Plain[];
+};
+
+export type Quote = {
+    type: "QUOTE";
+    value: Paragraph[];
+};
+
+export type Markup = Italic | Strike | Bold | Plain | ChannelMention;
+export type MarkupExcluding<T extends Markup> = Exclude<Markup, T>;
+
+export type Bold = {
+    type: "BOLD";
+    value: Array<
+        | MarkupExcluding<Bold>
+        | Link
+        | Emoji
+        | UserMention
+        | ChannelMention
+        | InlineCode
+    >;
+};
+
+export type Italic = {
+    type: "ITALIC";
+    value: Array<
+        | MarkupExcluding<Italic>
+        | Link
+        | Emoji
+        | UserMention
+        | ChannelMention
+        | InlineCode
+    >;
+};
+
+export type Strike = {
+    type: "STRIKE";
+    value: Array<
+        | MarkupExcluding<Strike>
+        | Link
+        | Emoji
+        | UserMention
+        | ChannelMention
+        | InlineCode
+        | Italic
+        | Timestamp
+    >;
+};
+
+export type Plain = {
+    type: "PLAIN_TEXT";
+    value: string;
+};
+
+export type LineBreak = {
+    type: "LINE_BREAK";
+    value: undefined;
+};
+
+export type KaTeX = {
+    type: "KATEX";
+    value: string;
+};
+
+export type InlineKaTeX = {
+    type: "INLINE_KATEX";
+    value: string;
+};
+
+export type Paragraph = {
+    type: "PARAGRAPH";
+    value: Array<Exclude<Inlines, Paragraph>>;
+};
+
+export type Image = {
+    type: "IMAGE";
+    value: {
+        src: Plain;
+        label: Markup;
+    };
+};
+
+export type Link = {
+    type: "LINK";
+    value: {
+        src: Plain;
+        label: Markup | Markup[];
+    };
+};
+
+export type UserMention = {
+    type: "MENTION_USER";
+    value: Plain;
+};
+
+export type ChannelMention = {
+    type: "MENTION_CHANNEL";
+    value: Plain;
+};
+
+export type Timestamp = {
+    type: "TIMESTAMP";
+    value: {
+        timestamp: string;
+        format: "t" | "T" | "d" | "D" | "f" | "F" | "R";
+    };
+    fallback?: Plain;
+};
+
+export type Types = {
+    BOLD: Bold;
+    PARAGRAPH: Paragraph;
+    PLAIN_TEXT: Plain;
+    ITALIC: Italic;
+    STRIKE: Strike;
+    CODE: Code;
+    CODE_LINE: CodeLine;
+    INLINE_CODE: InlineCode;
+    HEADING: Heading;
+    QUOTE: Quote;
+    LINK: Link;
+    MENTION_USER: UserMention;
+    MENTION_CHANNEL: ChannelMention;
+    EMOJI: Emoji;
+    BIG_EMOJI: BigEmoji;
+    COLOR: Color;
+    TASKS: Tasks;
+    TASK: Task;
+    UNORDERED_LIST: UnorderedList;
+    ORDERED_LIST: OrderedList;
+    LIST_ITEM: ListItem;
+    IMAGE: Image;
+    LINE_BREAK: LineBreak;
+};
+
+export type ASTNode =
+    | BigEmoji
+    | Bold
+    | Paragraph
+    | Plain
+    | Italic
+    | Strike
+    | Code
+    | CodeLine
+    | InlineCode
+    | Heading
+    | Quote
+    | Link
+    | UserMention
+    | ChannelMention
+    | Emoji
+    | Color
+    | Tasks;
+
+export type TypesKeys = keyof Types;
+
+export type Inlines =
+    | Markup
+    | Timestamp
+    | InlineCode
+    | Image
+    | Link
+    | UserMention
+    | Emoji
+    | Color
+    | InlineKaTeX;
+
+export type Blocks =
+    | Code
+    | Heading
+    | Quote
+    | ListItem
+    | Tasks
+    | OrderedList
+    | UnorderedList
+    | LineBreak
+    | KaTeX;
+
+type MessageBlock =
+    | Emoji
+    | ChannelMention
+    | UserMention
+    | Link
+    | MarkupExcluding<Bold>
+    | InlineCode;
+
+type RootNode = Paragraph | Blocks | BigEmoji
+
+export type Root = RootNode[];
+type AnyNode = Root[number] | Inlines | { type: undefined; fallback: Plain };
+
+const esc = (s: string) =>
+    s.replace(
+        /[&<>"']/g,
+        (c) =>
+            ({
+                "&": "&amp;",
+                "<": "&lt;",
+                ">": "&gt;",
+                '"': "&quot;",
+                "'": "&#39;",
+            }[c]!)
+    );
+
+const stripHtml = (s: string) => s.replace(/<[^>]*>/g, "");
+
+export const createTeamsHTMLMessage = (root: Root, siteUrl: string) => {
+    const renderChildren = (arr: AnyNode[] | undefined) =>
+        (arr ?? []).map(render).join("");
+    const renderInlineArray = (
+        arr: (Inlines | { type: undefined; fallback: Plain })[]
+    ) => arr.map(render).join("");
+
+    const render = (node: AnyNode): string => {
+        const n = node;
+        if (!n || !n.type) {
+            if (n?.fallback) return render(n.fallback);
+            return "";
+        }
+
+        switch (n.type) {
+            // --- blocks & groups ---
+            case "PARAGRAPH": {
+                return `<p>${n.value.map(render).join("")}</p>`;
+            }
+            case "HEADING": {
+                const tag = `h${n.level}`;
+                return `<${tag}>${n.value.map(render).join("")}</${tag}>`;
+            }
+            case "UNORDERED_LIST": {
+                return `<ul>${n.value
+                    .map((li) => `<li>${li.value.map(render).join("")}</li>`)
+                    .join("")}</ul>`;
+            }
+            case "ORDERED_LIST": {
+                return `<ol>${n.value
+                    .map((li) => {
+                        const liNode = li;
+                        const numberAttr =
+                            liNode.number != null
+                                ? ` value="${liNode.number}"`
+                                : "";
+                        return `<li${numberAttr}>${liNode.value
+                            .map(render)
+                            .join("")}</li>`;
+                    })
+                    .join("")}</ol>`;
+            }
+            case "TASKS": {
+                // Teams-friendly: represent as checklist-like list
+                return `<ul>${n.value
+                    .map((t) => {
+                        const task = t;
+                        const checkbox = task.status ? "☑" : "☐";
+                        return `<li>${checkbox} ${task.value
+                            .map(render)
+                            .join("")}</li>`;
+                    })
+                    .join("")}</ul>`;
+            }
+            case "QUOTE": {
+                return `<blockquote>${n.value.map(render).join("")}</blockquote>`;
+            }
+            case "CODE": {
+                const code = n.value
+                    .map((cl) => cl.value.value)
+                    .join("\n");
+                const lang = n.language
+                    ? ` data-lang="${esc(n.language)}" class="language-${esc(
+                        n.language
+                    )}"`
+                    : "";
+                return `<pre><code${lang}>${esc(code)}</code></pre>`;
+            }
+            case "KATEX": {
+                // Defer actual KaTeX rendering; Teams HTML usually needs pre-rendered math.
+                return `<span>${esc(n.value)}</span>`;
+            }
+            case "LINE_BREAK":
+                return "<br />";
+            case "BIG_EMOJI": {
+                return n.value.map(render).join("");
+            }
+
+            // --- inlines ---
+            case "PLAIN_TEXT": {
+                return esc(n.value);
+            }
+            case "BOLD": {
+                return `<strong>${renderInlineArray(n.value as any)}</strong>`;
+            }
+            case "ITALIC": {
+                return `<em>${renderInlineArray(n.value as any)}</em>`;
+            }
+            case "STRIKE": {
+                return `<s>${renderInlineArray(n.value as any)}</s>`;
+            }
+            case "INLINE_CODE": {
+                return `<code>${esc(n.value.value)}</code>`;
+            }
+            case "LINK": {
+                const href = esc(n.value.src.value);
+                const label = Array.isArray(n.value.label)
+                    ? n.value.label.map(render).join("")
+                    : render(n.value.label as any);
+                return `<a href=\"${href}\" title=\"${label}\" target=\"_blank\" rel=\"noreferrer noopener\">${label}</a>`;
+            }
+            case "IMAGE": {
+                const src = esc(n.value.src.value);
+                const alt = esc(
+                    stripHtml(
+                        Array.isArray(n.value.label)
+                            ? n.value.label.map(render).join("")
+                            : render(n.value.label as any)
+                    )
+                );
+                return `<img src="${src}" alt="${alt}" />`;
+            }
+            case "MENTION_USER": {
+                return `@${esc(n.value.value)}`;
+            }
+            case "MENTION_CHANNEL": {
+                return `#${esc(n.value.value)}`;
+            }
+            case "EMOJI": {
+                const v = 'shortCode' in n ? shortnameToUnicode(`:${n.shortCode}:`) : n.unicode;
+                return esc(v);
+            }
+            case "COLOR": {
+                const { r, g, b, a } = n.value; // a is 0..255 per your type
+                const alpha = (a ?? 255) / 255; // CSS expects 0..1
+                const swatch = `<span style="background-color: rgba(${r}, ${g}, ${b}, ${alpha}); display:inline-block; width:1em; height:1em; vertical-align:middle; margin-inline-end:.5em;"></span>`;
+                return `${swatch}rgba(${r}, ${g}, ${b}, ${alpha})`;
+            }
+            case "INLINE_KATEX": {
+                return `<span>${esc(n.value)}</span>`;
+            }
+            case "TIMESTAMP": {
+                // Teams doesn't render Discord-like formats; print fallback if present
+                if (n.fallback) return esc(n.fallback.value);
+                return `<time data-timestamp="${esc(
+                    n.value.timestamp
+                )}" data-format="${n.value.format}">${esc(
+                    n.value.timestamp
+                )}</time>`;
+            }
+
+            default:
+                return "";
+        }
+    };
+    return root.map(render).join("");
+};
+
+
+export const attachAttachments = (html: string, attachmentIds: string[]) => {
+    return (html + `<p>${attachmentIds.map(id => `<attachment id="${id}"></attachment>`).join("")}</p>`);
+}

--- a/lib/TeamsMessageParser.ts
+++ b/lib/TeamsMessageParser.ts
@@ -1,0 +1,208 @@
+import { parse } from 'himalaya';
+import { decode } from "he";
+import { Attachment } from './MicrosoftGraphApi';
+import { retrieveMessageIdMappingByTeamsMessageIdAsync } from './PersistHelper';
+import { IRead } from '@rocket.chat/apps-engine/definition/accessors';
+import { getRocketChatMessageUrl } from './UrlHelper';
+import { TeamsAttachmentType } from './Const';
+
+export type NodeType = "element" | "comment" | "text";
+
+/** Positions (present only when includePositions: true) */
+export interface Position {
+    index: number;
+    line: number;
+    column: number;
+}
+
+export interface NodePosition {
+    start: Position;
+    end: Position;
+}
+
+/** Base node */
+export interface BaseNode {
+    type: NodeType;
+    /** Included only when parser is configured with includePositions: true */
+    position?: NodePosition;
+}
+
+/** Attribute on an element */
+export interface Attribute {
+    key: string;
+    /**
+     * For standalone attributes like `disabled`, the value is `null`.
+     * Some emitters may omit the property entirely, so it's optional.
+     */
+    value?: string | null;
+}
+
+/** Element node: tags like <body>, <div>, <style> */
+export interface ElementNode extends BaseNode {
+    type: "element";
+    tagName: string;
+    children: Node[];
+    attributes: Attribute[];
+}
+
+/** Comment node: <!-- comment --> */
+export interface CommentNode extends BaseNode {
+    type: "comment";
+    content: string;
+}
+
+/** Text node */
+export interface TextNode extends BaseNode {
+    type: "text";
+    content: string;
+}
+
+/** Union of all node kinds */
+export type Node = ElementNode | CommentNode | TextNode;
+
+/** Parser options (for reference) */
+export interface ParseOptions {
+    includePositions?: boolean;
+}
+
+/** Typical parse return: a list of top-level nodes (document or fragment) */
+export type ParseResult = Node[];
+
+export function parseHTML(input: string, options?: ParseOptions): ParseResult {
+    return parse(input, options);
+}
+
+export async function buildRocketChatMessageText({
+    nodes,
+    attachments,
+    read,
+}: {
+    nodes: ParseResult;
+    attachments?: Attachment[];
+    read: IRead;
+}): Promise<string> {
+    async function parseNode(node: Node, extra?: Record<string, any>): Promise<string> {
+        if (node.type === "text") {
+            return decode(node.content);
+        } else if (node.type === "element") {
+            switch (node.tagName) {
+                case "a":
+                    const href = node.attributes.find(
+                        (attr) => attr.key === "href"
+                    )?.value;
+                    return `[${(await Promise.all(node.children.map((c) => parseNode(c)))).join("")}](${href})`;
+                case "b":
+                case "strong":
+                    if (node.children.length === 0) {
+                        return ``;
+                    }
+                    return `**${(await Promise.all(node.children.map((c) => parseNode(c)))).join("")}**`;
+                case "i":
+                case "em":
+                    if (node.children.length === 0) {
+                        return ``;
+                    }
+                    return `_${(await Promise.all(node.children.map((c) => parseNode(c)))).join("")}_`;
+                case "br":
+                    return `\n`;
+                case "p":
+                    return `${(await Promise.all(node.children.map((c) => parseNode(c)))).join("")}`;
+                case "s":
+                case "strike":
+                    if (node.children.length === 0) {
+                        return ``;
+                    }
+                    return `~~${(await Promise.all(node.children.map((c) => parseNode(c)))).join("")}~~`;
+                case 'ul':
+                    if (node.children.length === 0) {
+                        return ``;
+                    }
+                    return (await Promise.all(node.children.map((c) => parseNode(c, { ul: true })))).join("");
+                case "ol":
+                    if (node.children.length === 0) {
+                        return ``;
+                    }
+                    let index = 1;
+                    return (
+                        await Promise.all(
+                            node.children.map((c) =>
+                                parseNode(c, {
+                                    ol: true,
+                                    index:
+                                        "tagName" in c && c.tagName === "li"
+                                            ? index++
+                                            : undefined,
+                                })
+                            )
+                        )
+                    ).join("");
+                case "li":
+                    if (node.children.length === 0) {
+                        return ``;
+                    }
+                    if (extra?.ol) {
+                        return `${extra?.index ? extra.index : 1}. ${(
+                            await Promise.all(
+                                node.children.map((c) => parseNode(c))
+                            )
+                        ).join("")}\n`;
+                    } else {
+                        return `- ${(
+                            await Promise.all(
+                                node.children.map((c) => parseNode(c))
+                            )
+                        ).join("")}\n`;
+                    }
+
+                case 'blockquote':
+                    if (node.children.length === 0) {
+                        return ``;
+                    }
+                    const text = (await Promise.all(node.children.map((c) => parseNode(c)))).join("");
+                    const lines = text.split("\n").map(line => `> ${line}`);
+                    if (lines.length > 0 && lines[lines.length - 1] === "> ") {
+                        lines.pop();
+                    }
+                    return lines.join("\n");
+
+                case 'emoji':
+                    return node.attributes.find(attr => attr.key === 'alt')?.value ?? '';
+
+                case "attachment":
+                    const id = node.attributes.find(
+                        (attr) => attr.key === "id"
+                    )?.value;
+                    if (!id) {
+                        return ``;
+                    }
+                    const attachment = attachments?.find((att) => att.id === id);
+                    switch (attachment?.contentType) {
+                        case TeamsAttachmentType.MessageReference:
+                            let msgUrl = "";
+                            const mapping =
+                                await retrieveMessageIdMappingByTeamsMessageIdAsync(
+                                    read,
+                                    attachment.id
+                                );
+                            if (mapping?.rocketChatMessageId) {
+                                const msg = await read.getMessageReader().getById(mapping.rocketChatMessageId);
+                                if (msg?.id) {
+                                    msgUrl = await getRocketChatMessageUrl(read, msg.id, msg.room);
+                                }
+                            }
+                            return msgUrl;
+                        default:
+                            return ``;
+                    }
+                default:
+                    return (await Promise.all(node.children.map((c) => parseNode(c)))).join("");
+            }
+        } else {
+            return "";
+        }
+    }
+    const results = await Promise.all(
+        nodes.map((node) => parseNode(node))
+    );
+    return results.join("");
+}

--- a/lib/UrlHelper.ts
+++ b/lib/UrlHelper.ts
@@ -1,4 +1,4 @@
-import { IAppAccessors } from "@rocket.chat/apps-engine/definition/accessors";
+import { IAppAccessors, IRead } from "@rocket.chat/apps-engine/definition/accessors";
 import { IApiEndpointMetadata } from "@rocket.chat/apps-engine/definition/api";
 import {
     AuthenticationScopes,
@@ -7,6 +7,7 @@ import {
 } from "./Const";
 
 import { AppSetting } from "../config/Settings";
+import { IRoom } from "@rocket.chat/apps-engine/definition/rooms";
 
 export const getRocketChatAppEndpointUrl = async (
     appAccessors: IAppAccessors,
@@ -76,3 +77,21 @@ export const getLoginUrl = (
 
     return url;
 };
+
+
+export const getRocketChatMessageUrl = async (read: IRead, msgId: string, room: IRoom) => {
+    const siteUrl = await read.getEnvironmentReader().getServerSettings().getValueById("Site_Url");
+    let roomType = 'channel';
+    switch (room.type) {
+        case 'p':
+            roomType = 'group';
+            break;
+        case 'd':
+            roomType = 'direct';
+            break;
+        case 'c':
+        default:
+            roomType = 'channel';
+    }
+    return `${siteUrl}/${roomType}/${room.id}?msg=${msgId}`;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
                 "@rocket.chat/icons": "^0.32.0",
                 "@rocket.chat/ui-kit": "^0.31.22",
                 "crypto-js": "^4.1.1",
+                "he": "^1.2.0",
+                "himalaya": "^1.1.1",
                 "ms": "^2.1.3"
             },
             "devDependencies": {
@@ -340,6 +342,21 @@
             "engines": {
                 "node": ">=4"
             }
+        },
+        "node_modules/he": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+            "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+            "license": "MIT",
+            "bin": {
+                "he": "bin/he"
+            }
+        },
+        "node_modules/himalaya": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/himalaya/-/himalaya-1.1.1.tgz",
+            "integrity": "sha512-mJLY5tErGWtsw8hO2fJ2vK4IpG6S1AIgVkduRo4FqFJhgI2H3XLzgemRemk45zcnFyxNNpOfrIDle2KcnJM0lA==",
+            "license": "ISC"
         },
         "node_modules/hoek": {
             "version": "6.1.3",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
         "@rocket.chat/icons": "^0.32.0",
         "@rocket.chat/ui-kit": "^0.31.22",
         "crypto-js": "^4.1.1",
+        "he": "^1.2.0",
+        "himalaya": "^1.1.1",
         "ms": "^2.1.3"
     }
 }


### PR DESCRIPTION
## Summary

This PR introduces major improvements to the Rocket.Chat ↔ Microsoft Teams bridge, focusing on reliability, attachment handling, message formatting, and prevention of duplicate processing. It adds new parsing/rendering logic for rich messages, ensures consistent file handling across platforms, and re-architects inbound notification processing to use scheduled jobs for improved stability.

---

## Features

* **Inbound notification scheduling**

  * Added `InboundNotificationProcessor` and switched `SubscriberEndpoint` to schedule jobs instead of processing inline.
  * Improves reliability and prevents endpoint blocking.

* **Attachment ↔ Teams mapping**

  * New persistence layer for upload/message mappings (`UploadMappingModel`, `persistUploadAndTeamsMappingAsync`, retrieval helpers).
  * Handles file-only messages and tracks uploads across both platforms.
 
* **Fixed issue where reply/quote messages from MS Teams were not synced to Rocket.Chat**
  * Teams quotes are now parsed and represented in Rocket.Chat (inline or threaded) instead of being dropped.  

* **Encoding extra data in file names**

  * Introduced encoded filename scheme (`__extradata_<base64>`) to store extra info.
  * Pre-send hook restores the original filename in `message.file` and attachment titles.
  * This can be used to pass extra info to the file before sending it to room. Here, this is used to attach info that this message is from team and hence prevent from resending it to teams. Therefore, a loop is prevented.

* **Rich message parsing and rendering**

  * **Rocket.Chat → Teams**: new `RocketChatMessageParser` renders AST into Teams-friendly HTML (supports bold, italics, lists, tasks, quotes, code blocks, KaTeX, images, mentions, colors, big emoji, timestamps).
  * **Teams → Rocket.Chat**: new `TeamsMessageParser` converts Teams HTML into Rocket.Chat markdown, including support for blockquotes, lists, links, and message references.
  * New `mapRocketChatMessageToTeamsMessageV2` for improved bridged message formatting.

* **Prevent registry for recursion control**

  * Added `PreventRegistry` (persistence-backed) with `set`, `capture`, `release`, etc.
  * Prevents infinite loops and duplicate processing in pre/post message hooks.

---

## Fixes

* Skips echo messages to avoid infinite loops.
* Correctly resolves message ↔ upload ↔ Teams mappings on update/delete.
* Uses bridge user’s access token when sender’s token is missing, with helpful hint messages.
* Improved error logging for Graph API responses.
* Cleaned up persistence models (`MessageMappingModel`, `UploadMappingModel`).

---

## Improvements

* Better diagnostics with structured logging.
* Modularized mapping and sender resolution into helpers.
* Introduced `himalaya` + `he` for robust HTML parsing/decoding.
* Simplified code paths for message updates, deletes, and inbound handling.

---

## Breaking changes / Notes

* Inbound notifications are now scheduled (slight delay vs inline).
* New filename encoding scheme for files (`__extradata_<base64>`).
* Persistence keys for attachment mappings updated (`MiscKeys.AttachmentMapping`).

---

[SUP-848](https://rocketchat.atlassian.net/browse/SUP-848)
[SUP-848](https://rocketchat.atlassian.net/browse/SUP-848)
[SUP-851](https://rocketchat.atlassian.net/browse/SUP-851)
[SUP-857](https://rocketchat.atlassian.net/browse/SUP-857)

[SUP-848]: https://rocketchat.atlassian.net/browse/SUP-848?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ