### PR TITLE
fix: attachments, reply/quote handling and update behavior

### DIFF
--- a/TeamsBridgeApp.ts
+++ b/TeamsBridgeApp.ts
@@ -148,12 +148,15 @@ export class TeamsBridgeApp
             return true;
         });
 
-        if (pos !== -1) {
+        if (extraInfoData.source === 'ms-teams') {
             await PreventRegistry.set(
                 persistence,
                 `PreventPostMessageHook/${message.id}`,
                 true
             );
+        }
+
+        if (pos !== -1) {
             if (Array.isArray(message["_unmappedProperties_"]?.['files'])) {
                 message["_unmappedProperties_"]['files'] = message["_unmappedProperties_"]['files'].map((file) => {
                     if (file.name === message.attachments![pos].title?.value) {
@@ -508,7 +511,7 @@ export class TeamsBridgeApp
             persistence: IPersistence,
           ) => {
             try {
-                console.log(`Start renew registrations! (from: ${jobContext.from})`);
+                console.log(`[Teams Bridge] Start renew registrations! (from: ${jobContext.from})`);
                 let jobState = await retrieveSubscriptionRenewalJobState({ persistenceRead: read.getPersistenceReader() });
 
                 if (
@@ -519,7 +522,7 @@ export class TeamsBridgeApp
                         5 * 60 * 1000
                 ) {
                     // Job ran less than 5 minutes ago
-                    console.log(`${RegistrationAutoRenewSchedulerId} Job already ran less than 5 minutes ago. Skipping this run.`);
+                    console.log(`[Teams Bridge] ${RegistrationAutoRenewSchedulerId} Job already ran less than 5 minutes ago. Skipping this run.`);
                     return;
                 }
 
@@ -540,10 +543,10 @@ export class TeamsBridgeApp
                     persistence,
                     app: this,
                 });
-                console.log('Finish renew registrations!');
+                console.log('[Teams Bridge] Finish renew registrations!');
             } catch (error) {
                 throw new Error(
-                    `Auto renew registration failed with error: ${error}`,
+                    `[Teams Bridge] Auto renew registration failed with error: ${error}`,
                 );
             }
           }

--- a/app.json
+++ b/app.json
@@ -1,6 +1,6 @@
 {
     "id": "30d2e4bf-2402-4197-b844-e7082b07dc65",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "requiredApiVersion": "^1.40.0",
     "iconFile": "icon.png",
     "author": {

--- a/lib/EventHandler.ts
+++ b/lib/EventHandler.ts
@@ -1,5 +1,4 @@
 import {
-    IAppAccessors,
     IHttp,
     IModify,
     IPersistence,
@@ -29,9 +28,7 @@ import {
 import {
     combineRocketChatMessagesToTeamsMessage,
     generateHintMessageWithTeamsLoginButton,
-    getExtraInfoAndOriginalFileName,
     isBridgedMessageFormat,
-    mapRocketChatMessageToTeamsMessage,
     mapRocketChatMessageToTeamsMessageV2,
     notifyRocketChatUserAsync,
     notifyRocketChatUserInRoomAsync,
@@ -471,19 +468,28 @@ export const handlePostMessageSentAsync = async (options: {
             teamsMessageId = response.messageId;
             rocketChatMessageId = message.id as string;
         } else {
-            messageText = await mapRocketChatMessageToTeamsMessageV2({
+            const { text, attachments } = await mapRocketChatMessageToTeamsMessageV2({
                 message,
                 originalSenderName,
                 read,
+                http,
+                accessToken: userAccessToken,
+                messageIdMapping: {
+                    rocketChatMessageId,
+                    teamsMessageId,
+                    teamsThreadId: roomRecord.teamsThreadId,
+                }
             });
+            messageText = text;
 
             // Send the message to the chat thread
-            const response = await sendTextMessageToChatThreadAsync(
+            const response = await sendTextMessageToChatThreadAsync({
                 http,
-                messageText,
-                roomRecord.teamsThreadId,
-                userAccessToken
-            );
+                textMessage: messageText,
+                threadId: roomRecord.teamsThreadId,
+                userAccessToken,
+                attachments,
+            });
 
             teamsMessageId = response.messageId;
             rocketChatMessageId = message.id as string;
@@ -543,7 +549,6 @@ export const handlePostMessageUpdatedAsync = async (options: {
             `PreventPostMessageUpdateHook/${message.id}`
         )
     ) {
-       //  console.log("Message update was prevented from being processed.");
         return;
     }
 
@@ -570,17 +575,22 @@ export const handlePostMessageUpdatedAsync = async (options: {
             persistence,
             `PreventPostMessageUpdateHook/${message.id}`
         );
-        await updateTextMessageInChatThreadAsync(
+        const { text, attachments } =  await mapRocketChatMessageToTeamsMessageV2({
+            message,
+            read,
             http,
-            await mapRocketChatMessageToTeamsMessageV2({
-                message,
-                read,
-            }),
-            'html',
-            messageIdMapping.teamsMessageId,
-            messageIdMapping.teamsThreadId,
-            senderUserAccessToken
-        );
+            accessToken: senderUserAccessToken,
+            messageIdMapping,
+        })
+        await updateTextMessageInChatThreadAsync({
+            http,
+            textMessage: text,
+            messageType: 'html',
+            messageId: messageIdMapping.teamsMessageId,
+            threadId: messageIdMapping.teamsThreadId,
+            userAccessToken: senderUserAccessToken,
+            attachments,
+        });
     } else {
         const bridgeRoom = await retrieveRoomByTeamsThreadIdAsync(
             read,
@@ -615,19 +625,24 @@ export const handlePostMessageUpdatedAsync = async (options: {
                 persistence,
                 `PreventPostMessageUpdateHook/${message.id}`
             );
-            await updateTextMessageInChatThreadAsync(
+            const { text, attachments } = await mapRocketChatMessageToTeamsMessageV2({
+                message,
+                read,
+                originalSenderName: message.sender.name || message.sender.username,
+                forceBridgedMessage: true,
                 http,
-                await mapRocketChatMessageToTeamsMessageV2({
-                    message,
-                    read,
-                    originalSenderName: message.sender.name || message.sender.username,
-                    forceBridgedMessage: true
-                }),
-                'html',
-                messageIdMapping.teamsMessageId,
-                messageIdMapping.teamsThreadId,
-                bridgeUserAccessToken
-            );
+                accessToken: bridgeUserAccessToken,
+                messageIdMapping,
+            });
+            await updateTextMessageInChatThreadAsync({
+                http,
+                textMessage: text,
+                messageType: 'html',
+                messageId: messageIdMapping.teamsMessageId,
+                threadId: messageIdMapping.teamsThreadId,
+                userAccessToken: bridgeUserAccessToken,
+                attachments,
+            });
 
         } else {
             notifyNotLoggedInUserAsync(
@@ -650,11 +665,18 @@ export const handlePostMessageDeletedAsync = async (options: {
     http: IHttp;
 }): Promise<void> => {
     const { message, read, persistence, app, http } = options;
-    console.log("[Bridge] HandleDelete for message", message?.id);
+    if (
+        await PreventRegistry.capture(
+            persistence,
+            `PreventPostMessageDeleteHook/${message.id}`
+        )
+    ) {
+        // Prevent duplicate processing
+        return;
+    }
 
     const msgId = message.id;
     if (!msgId) {
-        console.log("[Bridge] Invalid message: missing id");
         return;
     }
 
@@ -671,7 +693,6 @@ export const handlePostMessageDeletedAsync = async (options: {
         !currentUploadMapping &&
         uploadMappings.length === 0
     ) {
-        console.log("[Bridge] No message or upload mapping found, skipping");
         return;
     }
 
@@ -685,7 +706,6 @@ export const handlePostMessageDeletedAsync = async (options: {
     });
 
     if (!senderUser || !accessToken) {
-        console.log("[Bridge] Missing sender info, skipping");
         return;
     }
 
@@ -713,7 +733,6 @@ export const handlePostMessageDeletedAsync = async (options: {
     };
 
     if (!teamsIds.messageId || !teamsIds.threadId) {
-        console.log("[Bridge] Missing Teams ids", teamsIds);
         return;
     }
 
@@ -723,11 +742,15 @@ export const handlePostMessageDeletedAsync = async (options: {
     };
 
     const isBridge = isBridgedMessageFormat(mainMessage?.text || "");
-    const { text, shouldDeleteTeamsMessage } =
+    const { text, shouldDeleteTeamsMessage, attachments } =
         await combineRocketChatMessagesToTeamsMessage({
             read,
             messages: mainMessage ? [mainMessage] : [],
-            teamsMessageId: teamsIds.messageId,
+            messageIdMapping: {
+                rocketChatMessageId: msgId,
+                teamsMessageId: teamsIds.messageId,
+                teamsThreadId: teamsIds.threadId,
+            },
             deletedMessages: deletedIds.messages,
             deletedUploads: deletedIds.uploads,
             forceBridgedMessage: isBridge,
@@ -735,10 +758,16 @@ export const handlePostMessageDeletedAsync = async (options: {
                 ? message.sender.name || message.sender.username
                 : undefined,
             uploadMappings,
+            http,
+            accessToken,
         });
 
     // --- Step 5: Execute Teams update/delete ---
     if (shouldDeleteTeamsMessage) {
+        await PreventRegistry.set(
+            persistence,
+            `PreventPostMessageDeleteHook/${message.id}`
+        );
         await deleteTextMessageInChatThreadAsync(
             http,
             senderUser.teamsUserId,
@@ -747,14 +776,19 @@ export const handlePostMessageDeletedAsync = async (options: {
             accessToken
         );
     } else {
-        await updateTextMessageInChatThreadAsync(
-            http,
-            text,
-            "html",
-            teamsIds.messageId,
-            teamsIds.threadId,
-            accessToken
+        await PreventRegistry.set(
+            persistence,
+            `PreventPostMessageUpdateHook/${message.id}`
         );
+        await updateTextMessageInChatThreadAsync({
+            http,
+            textMessage: text,
+            messageType: "html",
+            messageId: teamsIds.messageId,
+            threadId: teamsIds.threadId,
+            userAccessToken: accessToken,
+            attachments,
+        });
     }
 };
 

--- a/lib/InboundNotificationHelper.ts
+++ b/lib/InboundNotificationHelper.ts
@@ -30,6 +30,7 @@ import {
 } from "./PersistHelper";
 import { TeamsBridgeApp } from "../TeamsBridgeApp";
 import { getUserAccessTokenAsync } from "./AuthHelper";
+import { PreventRegistry } from "./PreventRegistry";
 
 export enum NotificationChangeType {
     Created = "created",
@@ -501,6 +502,14 @@ const handleInboundMessageUpdatedAsync = async (
         return;
     }
 
+    if (
+        await PreventRegistry.capture(
+            persis,
+            `PreventPostMessageUpdateHook/${messageIdMapping.rocketChatMessageId}`
+        )
+    ) {
+        return;
+    }
     const fromUserTeamsId = getMessageResponse.fromUserTeamsId;
     if (!fromUserTeamsId) {
         // If there's not a sender, stop processing
@@ -552,8 +561,19 @@ const handleInboundMessageDeletedAsync = async (
             read,
             resourceString
         );
+
     if (!messageIdMapping) {
         // If there's not an existing rocket chat message, stop processing
+        return;
+    }
+
+    if (
+        await PreventRegistry.capture(
+            persis,
+            `PreventPostMessageDeleteHook/${messageIdMapping.rocketChatMessageId}`
+        )
+    ) {
+        // Prevent duplicate processing
         return;
     }
 
@@ -571,6 +591,11 @@ const handleInboundMessageDeletedAsync = async (
     let messageBuilder = await updator.message(
         messageIdMapping.rocketChatMessageId,
         sender
+    );
+
+    await PreventRegistry.set(
+        persis,
+        `PreventPostMessageUpdateHook/${messageIdMapping.rocketChatMessageId}`
     );
     messageBuilder = messageBuilder
         .setText("~This message has been deleted.~")

--- a/lib/MessageHelper.ts
+++ b/lib/MessageHelper.ts
@@ -460,9 +460,7 @@ export const combineRocketChatMessagesToTeamsMessage = async ({
         )
     );
 
-    const text = results.map(r => {
-        return r.text
-    }).join('\n');
+    const text = results.map(r => r.text).join('\n');
 
     const parsedAttachments = results.map(r => r.attachments).reduce((acc, curr) => {
         acc.push(...curr);

--- a/lib/MessageHelper.ts
+++ b/lib/MessageHelper.ts
@@ -13,10 +13,10 @@ import { IUploadDescriptor } from "@rocket.chat/apps-engine/definition/uploads/I
 import { IUser } from "@rocket.chat/apps-engine/definition/users";
 import { shortnameToUnicode } from "emojione";
 import { LoginButtonText, TeamsAttachmentType } from "./Const";
-import { downloadOneDriveFileAsync, GetMessageResponse, MessageContentType } from "./MicrosoftGraphApi";
-import { buildRocketChatMessageText, extractMainTextNodesFromBridgedMessageNodes, Node, parseHTML, ParseResult } from "./TeamsMessageParser";
-import { attachAttachments, createTeamsHTMLMessage } from "./RocketChatMessageParser";
-import { retrieveUploadMappingsByTeamsMessageIdAsync, UploadMappingModel } from "./PersistHelper";
+import { downloadOneDriveFileAsync, getMessageAttachments, GetMessageResponse, MessageContentType } from "./MicrosoftGraphApi";
+import { buildRocketChatMessageText, extractMainTextNodesFromBridgedMessageNodes, parseHTML } from "./TeamsMessageParser";
+import { attachAttachments, attachMessageReferences, createTeamsHTMLMessage } from "./RocketChatMessageParser";
+import { MessageMappingModel, retrieveUploadMappingsByTeamsMessageIdAsync, UploadMappingModel } from "./PersistHelper";
 
 export const sendRocketChatOneOnOneMessageAsync = async (
     message: string,
@@ -165,7 +165,7 @@ export const mapTeamsMessageToRocketChatMessage = async ({
                                         modify,
                                     }
                                 );
-                                return upload;
+                                return { rocketChat: upload.id, teams: id };
                             } catch (error) {
                                 console.error(
                                     `Error downloading attachment: ${error.message}`
@@ -176,9 +176,9 @@ export const mapTeamsMessageToRocketChatMessage = async ({
                         return Promise.resolve(null);
                     })
                 )
-            ).forEach((upload, index) => {
-                if (upload) {
-                    uploadIds.push({ rocketChat: upload.id, teams: attachments[index].id });
+            ).forEach((uploadData) => {
+                if (uploadData) {
+                    uploadIds.push(uploadData);
                 }
             })
         }
@@ -223,13 +223,13 @@ export const isBridgedMessageFormat = (message: string): boolean => {
 
 export const getBridgedMessageFormatV2 = (
     originalSenderName: string,
-    message: string
+    message: string,
 ): string => {
     return (
         // Opening [Bridged Message] paragraph
         '<p style="font-size:14px; font-style:inherit; font-weight:inherit; margin-bottom:0; margin-left:0; margin-right:0; margin-top:0">' +
-            '<strong>[Bridged Message]</strong>' +
-        '</p>' +
+        "<strong>[Bridged Message]</strong>" +
+        "</p>" +
         // Opening blockquote for ms-teams
         '<blockquote style="font-size:14px; font-style:inherit; font-weight:inherit; margin:0.7rem 0">' +
             // Sender name paragraph
@@ -251,31 +251,51 @@ export const mapRocketChatMessageToTeamsMessageV2 = async ({
     originalSenderName,
     read,
     forceBridgedMessage,
-    siteUrl
+    siteUrl,
+    http,
+    accessToken,
+    messageIdMapping,
 }: {
     message: IMessage,
     originalSenderName?: string,
     read: IRead,
     forceBridgedMessage?: boolean,
     siteUrl?: string,
+    http: IHttp,
+    accessToken: string,
+    messageIdMapping: MessageMappingModel,
 }) => {
     // Handle emoji in text
     const text = message.text ?? "";
     const md = message[`_unmappedProperties_`]?.['md'] ?? [];
     if (md.length === 0 && text) {
-        return mapRocketChatMessageToTeamsMessage(text, originalSenderName);
+        return {
+            text: mapRocketChatMessageToTeamsMessage(text, originalSenderName),
+            attachments: []
+        };
     }
+
     const _siteUrl = siteUrl ?? await read.getEnvironmentReader().getServerSettings().getValueById("Site_Url") ?? "";
     let teamsMessage = createTeamsHTMLMessage(md, _siteUrl);
+    const { html: teamsMessageWithReferences, attachments: messageAttachments } = await attachMessageReferences(read, http, teamsMessage, accessToken);
+    const attachmentsFromTeams = await getMessageAttachments({
+        http,
+        messageId: messageIdMapping.teamsMessageId,
+        threadId: messageIdMapping.teamsThreadId,
+        userAccessToken: accessToken,
+    });
+    const attachmentsWithoutMessageAttachment = attachmentsFromTeams.filter(att => !messageAttachments.find(a => a?.id === att?.id));
+    const finalAttachments = [...messageAttachments, ...attachmentsWithoutMessageAttachment];
+    teamsMessage = attachAttachments({ html: teamsMessageWithReferences, attachmentIds: attachmentsWithoutMessageAttachment.map(a => a.id) });
 
     if (originalSenderName || forceBridgedMessage) {
         teamsMessage = getBridgedMessageFormatV2(
             originalSenderName || 'Rocket.Chat User',
-            teamsMessage
+            teamsMessage,
         );
     }
 
-    return teamsMessage;
+    return { text: teamsMessage, attachments: finalAttachments };
 };
 
 const downloadAttachmentFileFromExternalAndUploadToRocketChatAsync = async ({
@@ -404,23 +424,27 @@ export const combineRocketChatMessagesToTeamsMessage = async ({
     deletedUploads,
     forceBridgedMessage,
     originalSenderName,
-    teamsMessageId,
+    messageIdMapping,
+    http,
+    accessToken,
 }: {
     read: IRead;
-    teamsMessageId: string;
+    messageIdMapping: MessageMappingModel;
     messages: IMessage[];
     uploadMappings?: UploadMappingModel[];
     deletedMessages?: Set<string>;
     deletedUploads?: Set<string>;
     originalSenderName?: string;
     forceBridgedMessage?: boolean;
+    http: IHttp;
+    accessToken: string;
 }) => {
 
     const targetMessages = messages.filter(
         (message) => message.id && !deletedMessages?.has(message.id)
     );
 
-    const text = (
+    const results = (
         await Promise.all(
             targetMessages.map((message) =>
                 mapRocketChatMessageToTeamsMessageV2({
@@ -428,10 +452,22 @@ export const combineRocketChatMessagesToTeamsMessage = async ({
                     message,
                     originalSenderName,
                     forceBridgedMessage,
+                    http,
+                    accessToken,
+                    messageIdMapping,
                 })
             )
         )
-    ).join("<br/>");
+    );
+
+    const text = results.map(r => {
+        return r.text
+    }).join('\n');
+
+    const parsedAttachments = results.map(r => r.attachments).reduce((acc, curr) => {
+        acc.push(...curr);
+        return acc;
+    }, []);
 
     let targetUploadMappings: UploadMappingModel[];
     if (uploadMappings) {
@@ -441,17 +477,39 @@ export const combineRocketChatMessagesToTeamsMessage = async ({
     } else {
         targetUploadMappings = (await retrieveUploadMappingsByTeamsMessageIdAsync(
             read,
-            teamsMessageId
+            messageIdMapping.teamsMessageId
         )).filter(
             (uploadMap) => !deletedUploads?.has(uploadMap.rocketchatUploadId)
         );
     }
 
     const teamsAttachmentIds = targetUploadMappings.map(um => um.teamsAttachmentId);
+    const attachmentsFromTeams = await getMessageAttachments({
+        http,
+        messageId: messageIdMapping.teamsMessageId,
+        threadId: messageIdMapping.teamsThreadId,
+        userAccessToken: accessToken,
+    })
+
+    // Remove duplicate attachments by id
+    const allAttachments = [...parsedAttachments, ...attachmentsFromTeams];
+    const uniqueAttachmentsMap = new Map<string, any>();
+    for (const att of allAttachments) {
+        if (att && att.id && !uniqueAttachmentsMap.has(att.id)) {
+            uniqueAttachmentsMap.set(att.id, att);
+        }
+    }
+    const uniqueAttachments = Array.from(uniqueAttachmentsMap.values());
+    const finalAttachments = filterTeamsAttachments(uniqueAttachments, teamsAttachmentIds);
 
     return {
-        text: attachAttachments(text, teamsAttachmentIds),
+        text: attachAttachments({ html: text, attachmentIds: teamsAttachmentIds}),
         shouldDeleteTeamsMessage:
-            targetMessages.length === 0 && targetUploadMappings.length === 0,
+            targetMessages.length === 0 && teamsAttachmentIds.length === 0,
+        attachments: finalAttachments,
     };
 }
+
+export const filterTeamsAttachments = (attachments: any[], toKeepIds: string[]): any[] => {
+    return attachments.filter(att => toKeepIds.includes(att.id));
+};

--- a/lib/MicrosoftGraphApi.ts
+++ b/lib/MicrosoftGraphApi.ts
@@ -606,19 +606,28 @@ export const removeMemberFromChatThreadAsync = async (
     }
 };
 
-export const sendTextMessageToChatThreadAsync = async (
-    http: IHttp,
-    textMessage: string,
-    threadId: string,
-    userAccessToken: string) : Promise<SendMessageResponse> => {
+export const sendTextMessageToChatThreadAsync = async ({
+    http,
+    textMessage,
+    threadId,
+    userAccessToken,
+    attachments,
+}: {
+    http: IHttp;
+    textMessage: string;
+    threadId: string;
+    userAccessToken: string;
+    attachments?: any[];
+}): Promise<SendMessageResponse> => {
     const url = getGraphApiMessageUrl(threadId);
 
     const body = {
-        'body' : {
+        'body': {
             'content': textMessage,
             'contentType': 'html'
-        }
-    }
+        },
+        ...(attachments && { attachments })
+    };
 
     const httpRequest: IHttpRequest = {
         headers: {
@@ -636,8 +645,7 @@ export const sendTextMessageToChatThreadAsync = async (
             throw new Error('Send message to chat thread failed!');
         }
 
-
-        const result : SendMessageResponse = {
+        const result: SendMessageResponse = {
             messageId: responseBody.id,
         };
 
@@ -690,20 +698,34 @@ export const sendFileMessageToChatThreadAsync = async (
     }
 };
 
-export const updateTextMessageInChatThreadAsync = async (
-    http: IHttp,
-    textMessage: string,
-    messageType: 'text' | 'html',
-    messageId: string,
-    threadId: string,
-    userAccessToken: string) : Promise<void> => {
+export const updateTextMessageInChatThreadAsync = async ({
+    http,
+    textMessage,
+    messageType,
+    messageId,
+    threadId,
+    userAccessToken,
+    attachments,
+}: {
+    http: IHttp;
+    textMessage: string;
+    messageType: 'text' | 'html';
+    messageId: string;
+    threadId: string;
+    userAccessToken: string;
+    attachments?: any[];
+}): Promise<void> => {
     const url = getGraphApiMessageUrl(threadId, messageId, true);
 
-    const body = {
-        'body' : {
+    const body: any = {
+        'body': {
             'content': textMessage,
             'contentType': messageType
         },
+    };
+
+    if (attachments && attachments.length > 0) {
+        body.attachments = attachments;
     }
 
     const httpRequest: IHttpRequest = {
@@ -809,6 +831,84 @@ export const getMessageWithResourceStringAsync = async (
         return result;
     } else {
         throw new Error(`Get message with resource string failed with http status code ${response.statusCode}.`);
+    }
+}
+
+export const getReplyAttachment = async ({
+    http,
+    parentMessageId,
+    threadId,
+    userAccessToken
+}: {
+    http: IHttp;
+    userAccessToken: string;
+    parentMessageId: string;
+    threadId: string;
+}) => {
+    const url = getGraphApiMessageUrl(threadId, parentMessageId, false);
+
+    const httpRequest: IHttpRequest = {
+        headers: {
+            'Authorization': `Bearer ${userAccessToken}`,
+        },
+    };
+
+    const response = await http.get(url, httpRequest);
+
+    if (response.statusCode === HttpStatusCode.OK) {
+        const responseBody = response.data || {};
+        const { id, from, body } = responseBody;
+
+        if (!id || !from || !from.user || !body || !body.content) {
+            return;
+        }
+        return {
+            id,
+            contentType: 'messageReference',
+            content: JSON.stringify({
+                messageId: id,
+                messagePreview: body.content,
+                messageSender: {
+                    user: from.user,
+                }
+            })
+        }
+    } else {
+        console.error(`Get Teams message by ID failed with http status code ${response.statusCode}.`);
+        return;
+    }
+};
+
+export const getMessageAttachments = async ({
+    http,
+    messageId,
+    threadId,
+    userAccessToken
+}: {
+    http: IHttp;
+    userAccessToken: string;
+    messageId: string;
+    threadId: string;
+}) => {
+    const url = getGraphApiMessageUrl(threadId, messageId, false);
+
+    const httpRequest: IHttpRequest = {
+        headers: {
+            Authorization: `Bearer ${userAccessToken}`,
+        },
+    };
+
+    const response = await http.get(url, httpRequest);
+
+    if (response.statusCode === HttpStatusCode.OK) {
+        const { attachments = [] } = response.data || {};
+
+        return attachments as any[];
+    } else {
+        console.error(
+            `Get Teams message by ID failed with http status code ${response.statusCode}.`
+        );
+        return [];
     }
 }
 

--- a/lib/RocketChatMessageParser.ts
+++ b/lib/RocketChatMessageParser.ts
@@ -1,4 +1,8 @@
+import { IHttp, IRead } from "@rocket.chat/apps-engine/definition/accessors";
 import { shortnameToUnicode } from "emojione";
+import { MessageMappingModel, retrieveMessageIdMappingByRocketChatMessageIdAsync } from "./PersistHelper";
+import { getRocketChatMessageUrl } from "./UrlHelper";
+import { getReplyAttachment } from "./MicrosoftGraphApi";
 
 export type Blockquote = {
     type: "BLOCKQUOTE";
@@ -291,7 +295,7 @@ const stripHtml = (s: string) => {
     return s;
 };
 
-export const createTeamsHTMLMessage = (root: Root, siteUrl: string) => {
+export const createTeamsHTMLMessage = (root: Root, siteUrl?: string) => {
     const renderChildren = (arr: AnyNode[] | undefined) =>
         (arr ?? []).map(render).join("");
     const renderInlineArray = (
@@ -387,6 +391,17 @@ export const createTeamsHTMLMessage = (root: Root, siteUrl: string) => {
             }
             case "LINK": {
                 const href = esc(n.value.src.value);
+                if (siteUrl && href.includes(siteUrl)) {
+                    try {
+                        const url = new URL(href);
+                        const msgId = url.searchParams.get("msg");
+                        if (msgId) {
+                           return `<msg id="${msgId}"></msg>`;
+                        }
+                    } catch (e) {
+                        console.error("Invalid URL in LINK node:", href);
+                    }
+                }
                 const label = Array.isArray(n.value.label)
                     ? n.value.label.map(render).join("")
                     : render(n.value.label as any);
@@ -440,6 +455,104 @@ export const createTeamsHTMLMessage = (root: Root, siteUrl: string) => {
 };
 
 
-export const attachAttachments = (html: string, attachmentIds: string[]) => {
+export const attachAttachments = ({
+    html,
+    attachmentIds = [],
+}: {
+    html: string,
+    attachmentIds?: string[],
+}) => {
     return (html + `<p>${attachmentIds.map(id => `<attachment id="${id}"></attachment>`).join("")}</p>`);
 }
+/**
+ * Replace <msg id="..."></msg> tokens in HTML with Teams-friendly attachments or links.
+ * Returns the transformed html and any teams attachment ids found.
+ */
+export const attachMessageReferences = async (
+    read: IRead,
+    http: IHttp,
+    html: string,
+    accessToken: string,
+) => {
+    if (!html) {
+        return { html: '', attachments: [] };
+    }
+
+    const matches = html.match(/<msg id="([^"]+)"><\/msg>/g) || [];
+    if (matches.length === 0) {
+        return { html, attachments: [] };
+    }
+
+    const referencedIds = matches
+        .map((m) => {
+            const mm = m.match(/id="([^"]+)"/);
+            return mm?.[1];
+        })
+        .filter(Boolean) as string[];
+
+    const messageIdMappings: MessageMappingModel[] = [];
+    let transformed = html;
+
+    for (const rcMsgId of referencedIds) {
+        try {
+            // Try to find existing mapping (Rocket.Chat message -> Teams message)
+            const mapping = await retrieveMessageIdMappingByRocketChatMessageIdAsync(read, rcMsgId);
+
+
+            if (mapping?.teamsMessageId) {
+                // Replace token with a Teams attachment reference to the teams message id
+                const attachmentTag = `<attachment id="${mapping.teamsMessageId}"></attachment>`;
+                transformed = transformed.replace(
+                    new RegExp(`<msg id="${rcMsgId}"><\\/msg>`, 'g'),
+                    attachmentTag
+                );
+                messageIdMappings.push(mapping);
+                continue;
+            }
+
+            // If no mapping found, attempt to resolve Rocket.Chat message and produce a public link
+            const msg = await read.getMessageReader().getById(rcMsgId);
+            if (msg && msg.id && msg.room) {
+                try {
+                    const url = await getRocketChatMessageUrl(read, msg.id, msg.room);
+                    const link = `<a href="${url}" title="${url}" target="_blank" rel="noreferrer noopener">${url}</a>`;
+                    transformed = transformed.replace(
+                        new RegExp(`<msg id="${rcMsgId}"><\\/msg>`, 'g'),
+                        link
+                    );
+                    continue;
+                } catch {
+                    // fallback handled below
+                }
+            }
+
+            // Final fallback: remove token or replace with placeholder text
+            transformed = transformed.replace(
+                new RegExp(`<msg id="${rcMsgId}"><\\/msg>`, 'g'),
+                '[referenced message not available]'
+            );
+        } catch (err) {
+            // On unexpected error, leave a placeholder and continue
+            transformed = transformed.replace(
+                new RegExp(`<msg id="${rcMsgId}"><\\/msg>`, 'g'),
+                '[referenced message not available]'
+            );
+            console.error('[attachMessageReferences] error resolving reference', rcMsgId, err);
+        }
+    }
+
+    const attachments = (await Promise.all(
+        messageIdMappings.map(async (mp) => {
+            const teamsMessage = await getReplyAttachment({
+                http,
+                parentMessageId: mp.teamsMessageId,
+                threadId: mp.teamsThreadId,
+                userAccessToken: accessToken,
+            });
+            return teamsMessage;
+        })
+    )).filter((m) => !!m);
+
+
+    return { html: transformed, attachments };
+};

--- a/lib/TeamsMessageParser.ts
+++ b/lib/TeamsMessageParser.ts
@@ -187,7 +187,7 @@ export async function buildRocketChatMessageText({
                             if (mapping?.rocketChatMessageId) {
                                 const msg = await read.getMessageReader().getById(mapping.rocketChatMessageId);
                                 if (msg?.id) {
-                                    msgUrl = await getRocketChatMessageUrl(read, msg.id, msg.room);
+                                    msgUrl = `[ ](${await getRocketChatMessageUrl(read, msg.id, msg.room)})`;
                                 }
                             }
                             return msgUrl;
@@ -204,7 +204,7 @@ export async function buildRocketChatMessageText({
     const results = await Promise.all(
         nodes.map((node) => parseNode(node))
     );
-    return results.join("");
+    return results.join("").trim();
 }
 
 function findTagAtPosition(nodes: ParseResult, tag: string, pos: number): Node | undefined {


### PR DESCRIPTION
Small, focused fixes and improvements for the Teams ↔ Rocket.Chat bridge:

- Fix: preserve and sync Teams replies/quotes to Rocket.Chat (no longer dropped).
- Fix: avoid blanking RC messages when Teams returns empty content on soft-delete (skip empty updates).
- Feature: improved attachments mapping and de-duplication (persist upload ↔ teams attachments).
[SUP-860](https://rocketchat.atlassian.net/browse/SUP-860)

[SUP-860]: https://rocketchat.atlassian.net/browse/SUP-860?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ